### PR TITLE
Prevent prefetch hooks from being called if transition gets aborted

### DIFF
--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -18,7 +18,7 @@ export function initialize(instance) {
 
     transition.handlerInfos.forEach(function(handlerInfo) {
       // Don't prefetch handlers above the pivot.
-      if (!hasSeenPivot) {
+      if (!hasSeenPivot || transition.isAborted) {
         // The pivot is the first common ancestor, so it is skipped as well.
         if (handlerInfo.handler === pivotHandler) {
           hasSeenPivot = true;

--- a/tests/acceptance/abort-transition-test.js
+++ b/tests/acceptance/abort-transition-test.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+
+const { run } = Ember;
+
+module('Acceptance | abort-transition', {
+  beforeEach() {
+    this.application = startApp();
+    this.router = this.application.__container__.lookup('router:main');
+    window.AbortTransitionToChild_prefetch_count = 0;
+    window.AbortTransitionToChild_Child_prefetch_count = 0;
+  },
+
+  afterEach() {
+    this.router = null;
+    run(this.application, 'destroy');
+    delete window.AbortTransitionToChild_prefetch_count;
+    delete window.AbortTransitionToChild_Child_prefetch_count;
+  },
+});
+
+test('visiting /abort-transition-to-child/child aborts transition and doesn\'t run additional prefetch hooks', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(() => {
+    this.router.transitionTo('abort-transition-to-child.child');
+  });
+
+  andThen(() => {
+    assert.equal(currentURL(), '/', 'still on index (transition was aborted)');
+
+    assert.equal(window.AbortTransitionToChild_prefetch_count, 1, 'parent prefetch called');
+    assert.equal(window.AbortTransitionToChild_Child_prefetch_count, 0, 'child prefetch not called');
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,10 @@ Router.map(function() {
   this.route('foo');
   this.route('bar');
   this.route('queryparams');
+
+  this.route('abort-transition-to-child', function() {
+    this.route('child');
+  });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/abort-transition-to-child.js
+++ b/tests/dummy/app/routes/abort-transition-to-child.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  prefetch(params, transition) {
+    transition.abort();
+    window.AbortTransitionToChild_prefetch_count++;
+  },
+});

--- a/tests/dummy/app/routes/abort-transition-to-child/child.js
+++ b/tests/dummy/app/routes/abort-transition-to-child/child.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  prefetch() {
+    window.AbortTransitionToChild_Child_prefetch_count++;
+  },
+});


### PR DESCRIPTION
Adds a test and simple enhancement to prevent prefetch hooks from being called if a transition is aborted in a prior prefetch hook.
