### PR TITLE
Replace prefetched property with method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ App.PostCommentsRoute = Ember.Route.extend({
 The default functionality of the `model` hook will pick up whatever is returned from the `prefetch` hook.
 A route that defines a `prefetch` hook is not required to define a `model` hook.
 
-The `prefetched` property provides access to a route's prefetched data. `prefetched` will always be a promise, but ES7 async function syntax makes working with it easy.
+The `prefetched` method provides access to routes' prefetched data. `prefetched` will always return a promise, but ES7 async function syntax makes working with it easy.
 
 ```javascript
 App.PostCommentsRoute = Ember.Route.extend({
   prefetch(params, transition) {
-    return Ember.$.get(`/api/posts/${transition.params.post.id}/comments`);
+    return Ember.$.get(`/api/posts/${this.paramsFor('post').id}/comments`);
   },
 
   async model() {
     return {
-      OP: this.modelFor('post')).author,
-      comments: await this.prefetched
+      OP: (await this.prefetched('post')).author,
+      comments: await this.prefetched(),
     };
   }
 });

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -47,7 +47,7 @@ export function initialize(instance) {
       // the model hook should ignore the prefetched property.
       promise._prefetchReturnedUndefined = (!!promise._state && typeof promise._result === 'undefined');
 
-      handlerInfo.handler.prefetched = promise;
+      handlerInfo.handler._prefetched = promise;
     });
   });
 }

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -30,7 +30,7 @@ export default Ember.Mixin.create({
 
       model(params) {
         return Ember.RSVP.hash({
-          postAuthor: this.prefetched(this.routeName),
+          postAuthor: this.prefetched(),
           comments: this.store.findAll('comment')
         });
       }
@@ -38,18 +38,20 @@ export default Ember.Mixin.create({
     ```
 
     @method prefetched
-    @param {String} name the name of the route
-    @return {Promise} a promise that resolves with the prefetched data
+    @param {String} [name] - The name of the route. Defaults to the current route if no name is given.
+    @return {Promise} A promise that resolves with the prefetched data.
     @public
   */
-  // prefetched(name) {
-  //   var route = this.container.lookup(`route:${name}`);
-  //   return Ember.RSVP.Promise.resolve(route && route.asyncData);
-  // },
-
+  prefetched(name) {
+    if (arguments.length < 1) {
+      name = this.routeName;
+    }
+    const route = this.container.lookup(`route:${name}`);
+    return Ember.RSVP.Promise.resolve(route && route._prefetched);
+  },
 
   model(params, transition) {
-    const prefetched = this.prefetched;
+    const prefetched = this._prefetched;
 
     if (prefetched && !prefetched._prefetchReturnedUndefined) {
       return prefetched;

--- a/tests/unit/initializers/prefetch-test.js
+++ b/tests/unit/initializers/prefetch-test.js
@@ -28,7 +28,7 @@ test('an Ember#Route\'s default model hook returns its prefetched property', fun
   initialize(registry, application);
 
   const data = { _prefetchReturnedUndefined: false };
-  const route = Ember.Route.create({ prefetched: data });
+  const route = Ember.Route.create({ _prefetched: data });
 
   assert.equal(route.model(), data, 'the model hook returns prefetched');
 });

--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -44,10 +44,10 @@ test('the prefetch hook is invoked', function(assert) {
 
   assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
   assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
-  assert.equal(handler.prefetched, promise, 'the promise is set on the handler as prefetched');
+  assert.equal(handler._prefetched, promise, 'the promise is set on the handler as _prefetched');
 });
 
-test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(assert) {
+test('handler._prefetched._prefetchReturnedUndefined is set correctly', function(assert) {
   assert.expect(2);
 
   initialize(instance);
@@ -65,7 +65,7 @@ test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(
   const transitionWithValue = { handlerInfos: handlerInfosWithValue };
 
   router.trigger('willTransition', transitionWithValue);
-  assert.notOk(handler.prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is false because the promise was resolved with something other than undefined');
+  assert.notOk(handler._prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is false because the promise was resolved with something other than undefined');
 
   // simulate prefetch returning undefined
   const resolvedWithUndefined = new Ember.RSVP.resolve(undefined);
@@ -77,5 +77,5 @@ test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(
   const transitionWithUndefined = { handlerInfos: handlerInfosWithUndefined };
 
   router.trigger('willTransition', transitionWithUndefined);
-  assert.ok(handler.prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is true because the promise was resolved with undefined');
+  assert.ok(handler._prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is true because the promise was resolved with undefined');
 });


### PR DESCRIPTION
Implements `Route#prefetched` as a method akin to `Route.modelFor`.
