### PR TITLE
Make redirect patch apply to Route#refresh

### DIFF
--- a/addon/initializers/redirect-patch.js
+++ b/addon/initializers/redirect-patch.js
@@ -1,27 +1,48 @@
 import Ember from 'ember';
 
 let hasInitialized = false;
-
-function triggerAfterTransitioning() {
-  const oldInfos = this.router.state.handlerInfos;
-  const transition = this._super(...arguments);
-
-  // Router.js does not trigger `willTransition` when redirecting. We need
-  // `willTransition` to be triggered regardless so that the `prefetch` hook is
-  // always invoked for the routes in the new transition. Internally, the
-  // `willTransition` hook uses `Ember.run.once` to fire the event, which
-  // gurantees that it will not trigger `willTransition` multiple times.
-  this.willTransition(oldInfos, transition.state.handlerInfos, transition);
-
-  return transition;
-}
+let isOuter = true;
+let hasWillTransitioned = false;
 
 export function initialize() {
   if (!hasInitialized) {
     hasInitialized = true;
 
     Ember.Router.reopen({
-      transitionTo: triggerAfterTransitioning,
+      _initRouterJs() {
+        this._super.apply(this, arguments);
+
+        // now this.router is available
+        const router = this.router;
+        const emberRouter = this;
+
+        // replace router's transitionByIntent method, through which all transitions pass
+        const oldTransitionByIntent = router.transitionByIntent;
+        router.transitionByIntent = function() {
+          const localIsOuter = isOuter;
+          isOuter = false;
+
+          const oldInfos = router.state.handlerInfos;
+          const transition = oldTransitionByIntent.apply(router, arguments);
+
+          // Router.js does not trigger `willTransition` when redirecting. We need
+          // `willTransition` to be triggered regardless so that the `prefetch` hook is
+          // always invoked for the routes in the new transition. Internally, the
+          // `willTransition` hook uses `Ember.run.once` to fire the event, which
+          // gurantees that it will not trigger `willTransition` multiple times.
+          if (!hasWillTransitioned && transition) {
+            emberRouter.willTransition(oldInfos, transition.state.handlerInfos, transition);
+            hasWillTransitioned = true;
+          }
+
+          if (localIsOuter) {
+            hasWillTransitioned = false;
+            isOuter = true;
+          }
+
+          return transition;
+        };
+      },
     });
   }
 }

--- a/tests/acceptance/query-params-test.js
+++ b/tests/acceptance/query-params-test.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 
+const QUERYPARAMS_ROUTE_NAME = 'queryparams';
+const QUERYPARAMS_ROUTE_URL = '/queryparams';
+
 module('Acceptance | query-params', {
   beforeEach: function() {
     this.application = startApp();
@@ -15,26 +18,100 @@ module('Acceptance | query-params', {
   },
 });
 
-test('visiting a route with query params does not break the prefetch hook', function(assert) {
-  assert.expect(5);
+test('loading a route with a query param runs the prefetch hook', function(assert) {
+  assert.expect(3);
 
-  visit('/queryparams');
+  visit(`${QUERYPARAMS_ROUTE_URL}?foo=bar`);
 
   andThen(() => {
-    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'queryparams\' prefetch hook was invoked for the initial transition');
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?foo=bar', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'queryparams\' prefetch hook was invoked');
+  });
+});
 
-    this.router.transitionTo('queryparams', { queryParams: { foo: 'bar' } });
+test('loading a route with a query param marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit(`${QUERYPARAMS_ROUTE_URL}?fiz=baz`);
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fiz=baz', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'queryparams\' prefetch hook was invoked');
+  });
+});
+
+test('transitioning to a route with a query param runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(() => {
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { foo: 'bar' } });
   });
 
   andThen(() => {
-    assert.equal(currentURL(), '/queryparams?foo=bar', 'the URL contains the query params');
-    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'queryparams\' prefetch hook was not invoked again');
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?foo=bar', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run');
+  });
+});
 
-    this.router.transitionTo('queryparams', { queryParams: { fiz: 'baz', foo: null } });
+test('transitioning to a route with a query param marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(() => {
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: 'baz' } });
   });
 
   andThen(() => {
-    assert.equal(currentURL(), '/queryparams?fiz=baz', 'the URL contains the new query params');
-    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'queryparams\' prefetch hook was invoked again because fiz is marked with refreshModel');
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fiz=baz', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run');
+  });
+});
+
+test('changing a query param does not run the prefetch hook', function(assert) {
+  assert.expect(4);
+
+  visit(`${QUERYPARAMS_ROUTE_URL}`);
+
+  andThen(() => {
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run for the initial transition');
+
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { foo: 'bar' } });
+  });
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?foo=bar', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was not run again');
+  });
+});
+
+test('changing a query param marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(4);
+
+  visit(`${QUERYPARAMS_ROUTE_URL}`);
+
+  andThen(() => {
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run for the initial transition');
+
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: 'baz', foo: null } });
+  });
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fiz=baz', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'the prefetch hook was run again');
   });
 });


### PR DESCRIPTION
`Route#refresh` calls `router.js#refresh` directly, which bypasses the `willTransition` work around. Patching `router.js#transitionByIntent` instead of `Router#transitionTo` reduces the chance that there is an unaccounted for vector for redirecting.
- [x] Needs testing to prevent regression.
