### PR TITLE
Don't prefetch again for same transition & params

### DIFF
--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -23,28 +23,34 @@ module('Unit | Instance Initializer | prefetch', {
 });
 
 test('the prefetch hook is invoked', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   initialize(instance);
 
   const router = instance.lookup('router:main');
-  const promise = new Ember.RSVP.resolve(1);
-  const runSharedModelHook = this.stub().returns(promise);
-  const handler = {};
+  const promise1 = new Ember.RSVP.resolve(1);
+  const runSharedModelHook1 = this.stub().returns(promise1);
+  const handler1 = {};
+  const promise2 = new Ember.RSVP.resolve(1);
+  const runSharedModelHook2 = this.stub().returns(promise2);
+  const handler2 = {};
   const handlerInfos = [{
-    runSharedModelHook,
-    handler,
+    runSharedModelHook: runSharedModelHook1,
+    handler: handler1,
+    name: 'route1',
   }, {
-    runSharedModelHook,
-    handler,
+    runSharedModelHook: runSharedModelHook2,
+    handler: handler2,
+    name: 'route2',
   }];
   const transition = { handlerInfos };
 
   router.trigger('willTransition', transition);
 
-  assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
-  assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
-  assert.equal(handler.prefetched, promise, 'the promise is set on the handler as prefetched');
+  assert.ok(runSharedModelHook1.calledOnce && runSharedModelHook2.calledOnce, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
+  assert.ok(runSharedModelHook1.calledWith(transition, 'prefetch') && runSharedModelHook2.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
+  assert.equal(handler1.prefetched, promise1, 'promise1 is set on handler1 as prefetched');
+  assert.equal(handler2.prefetched, promise2, 'promise2 is set on handler2 as prefetched');
 });
 
 test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(assert) {
@@ -66,6 +72,7 @@ test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(
 
   router.trigger('willTransition', transitionWithValue);
   assert.notOk(handler.prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is false because the promise was resolved with something other than undefined');
+  router.trigger('didTransition');
 
   // simulate prefetch returning undefined
   const resolvedWithUndefined = new Ember.RSVP.resolve(undefined);
@@ -78,4 +85,5 @@ test('handler.prefetched._prefetchReturnedUndefined is set correctly', function(
 
   router.trigger('willTransition', transitionWithUndefined);
   assert.ok(handler.prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is true because the promise was resolved with undefined');
+  router.trigger('didTransition');
 });


### PR DESCRIPTION
Prevents a route's `prefetch` hook from being invoked multiple times for the same transition/parameters when a redirect occurs.
- [ ] Needs testing to prevent regression.
