### PR TITLE
Remove overzealous assertion

### DIFF
--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -5,8 +5,6 @@ export function initialize(instance) {
   const router = (typeof instance.lookup === 'function' ? instance.lookup(ROUTER_NAME) : instance.container.lookup(ROUTER_NAME));
 
   router.on('willTransition', function(transition) {
-    Ember.assert('Router#willTransition was fired with a transition that has no handlerInfos, but is not a queryParamOnly transition.', transition.handlerInfos || transition.queryParamsOnly);
-
     if (!transition.handlerInfos) {
       return;
     }


### PR DESCRIPTION
Sorry for leading astray on this one. Apparently this is valid if a route tries to navigate to itself.
