### PR TITLE
Decouple prefetch from RSVP Promise internals

### DIFF
--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -38,14 +38,7 @@ export function initialize(instance) {
       }
 
       // Run the prefetch hook if the route has one.
-      const promise = handlerInfo.runSharedModelHook(transition, 'prefetch', [fullParams]);
-
-      // runSharedModelHook always returns a promise. We check to see if the
-      // promise has already resolved with a value of undefined. If it has,
-      // the model hook should ignore the prefetched property.
-      promise._prefetchReturnedUndefined = (!!promise._state && typeof promise._result === 'undefined');
-
-      handlerInfo.handler._prefetched = promise;
+      handlerInfo.handler._prefetched = handlerInfo.runSharedModelHook(transition, 'prefetch', [fullParams]);
     });
   });
 }

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const { Mixin, RSVP, getOwner } = Ember;
+const PREFETCH_NOT_DEFINED = {};
 
 /**
  * An implementation detail of testing the prefetch initializer.
@@ -53,13 +54,25 @@ export default Mixin.create({
     return RSVP.Promise.resolve(route && route._prefetched);
   },
 
-  model(params, transition) {
-    const prefetched = this._prefetched;
+  prefetch() {
+    return PREFETCH_NOT_DEFINED;
+  },
 
-    if (prefetched && !prefetched._prefetchReturnedUndefined) {
-      return prefetched;
+  model() {
+    const prefetched = this._prefetched;
+    const _super = this._super;
+
+    if (!prefetched) {
+      return _super.call(this, ...arguments);
     }
 
-    return this._super(params, transition);
+    return prefetched.then((value) => {
+      // If a prefetch hook is not defined, the default model hook is used.
+      if (value === PREFETCH_NOT_DEFINED) {
+        return _super.call(this, ...arguments);
+      }
+
+      return value;
+    });
   },
 });

--- a/tests/unit/initializers/prefetch-test.js
+++ b/tests/unit/initializers/prefetch-test.js
@@ -27,8 +27,10 @@ test('an Ember#Route\'s default model hook returns its prefetched property', fun
 
   initialize(registry, application);
 
-  const data = { _prefetchReturnedUndefined: false };
-  const route = Ember.Route.create({ _prefetched: data });
+  const data = {};
+  const route = Ember.Route.create({ _prefetched: Ember.RSVP.Promise.resolve(data) });
 
-  assert.equal(route.model(), data, 'the model hook returns prefetched');
+  return route.model().then((model) => {
+    assert.equal(model, data, 'the model hook returns prefetched');
+  });
 });

--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -3,7 +3,7 @@ import { initialize } from '../../../instance-initializers/prefetch';
 import { module } from 'qunit';
 import test from 'dummy/tests/ember-sinon-qunit/test';
 
-var application, instance;
+let application, instance;
 
 module('Unit | Instance Initializer | prefetch', {
   beforeEach() {
@@ -23,20 +23,21 @@ module('Unit | Instance Initializer | prefetch', {
 });
 
 test('the prefetch hook is invoked', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   initialize(instance);
 
   const router = instance.lookup('router:main');
   const promise = new Ember.RSVP.resolve(1);
   const runSharedModelHook = this.stub().returns(promise);
-  const handler = {};
+  const handler1 = {};
+  const handler2 = {};
   const handlerInfos = [{
     runSharedModelHook,
-    handler,
+    handler: handler1,
   }, {
     runSharedModelHook,
-    handler,
+    handler: handler2,
   }];
   const transition = { handlerInfos };
 
@@ -44,38 +45,6 @@ test('the prefetch hook is invoked', function(assert) {
 
   assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
   assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
-  assert.equal(handler._prefetched, promise, 'the promise is set on the handler as _prefetched');
-});
-
-test('handler._prefetched._prefetchReturnedUndefined is set correctly', function(assert) {
-  assert.expect(2);
-
-  initialize(instance);
-
-  const router = instance.lookup('router:main');
-  const handler = {};
-
-  // simulate prefetch returning a value
-  const resolvedWithValue = new Ember.RSVP.resolve(1);
-  const runSharedModelHookWithValue = this.stub().returns(resolvedWithValue);
-  const handlerInfosWithValue = [{
-    runSharedModelHook: runSharedModelHookWithValue,
-    handler,
-  }];
-  const transitionWithValue = { handlerInfos: handlerInfosWithValue };
-
-  router.trigger('willTransition', transitionWithValue);
-  assert.notOk(handler._prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is false because the promise was resolved with something other than undefined');
-
-  // simulate prefetch returning undefined
-  const resolvedWithUndefined = new Ember.RSVP.resolve(undefined);
-  const runSharedModelHookWithUndefined = this.stub().returns(resolvedWithUndefined);
-  const handlerInfosWithUndefined = [{
-    runSharedModelHook: runSharedModelHookWithUndefined,
-    handler,
-  }];
-  const transitionWithUndefined = { handlerInfos: handlerInfosWithUndefined };
-
-  router.trigger('willTransition', transitionWithUndefined);
-  assert.ok(handler._prefetched._prefetchReturnedUndefined, '_prefetchReturnedUndefined is true because the promise was resolved with undefined');
+  assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
+  assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
 });

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -1,15 +1,18 @@
 import Ember from 'ember';
+import { initialize } from '../../../instance-initializers/prefetch';
 import RouteMixin from 'ember-prefetch/mixins/route';
 import { module } from 'qunit';
 import test from 'dummy/tests/ember-sinon-qunit/test';
 
-var application, instance;
+const { Promise } = Ember.RSVP;
+let application, instance;
 
 module('Unit | Mixin | route', {
   beforeEach() {
     Ember.run(function() {
       application = Ember.Application.create();
       instance = application.buildInstance();
+      initialize(instance);
     });
   },
   afterEach() {
@@ -39,36 +42,18 @@ function registerRoute(name, obj) {
   return instance.lookup(longName);
 }
 
-test('the model hook doesn\'t die when route._prefetched is undefined', function(assert) {
+test('the case when route._prefetched is undefined is accounted for', function(assert) {
   assert.expect(1);
 
   const _super = this.spy();
   const route = classFromSpy(_super).create();
-  route.model();
+  try {
+    route.model();
+  } catch(e) {
+    assert.ok(false, 'the model hook doesn\'t die with route._prefetched is undefined');
+  }
 
-  assert.ok(_super.calledOnce, '_super is called');
-});
-
-test('the model hook returns route._prefetched if _prefetchReturnedUndefined is false', function(assert) {
-  assert.expect(2);
-
-  const data = { _prefetchReturnedUndefined: false };
-  const _super = this.spy();
-  const route = classFromSpy(_super).create({ _prefetched: data });
-
-  assert.equal(route.model(), data, 'the model hook returns route.prefetched');
-  assert.notOk(_super.called, '_super is not called');
-});
-
-test('the model hook calls super if _prefetchReturnedUndefined is true', function(assert) {
-  assert.expect(2);
-
-  const data = { _prefetchReturnedUndefined: true };
-  const _super = this.spy();
-  const route = classFromSpy(_super).create({ _prefetched: data });
-
-  assert.notEqual(route.model(), data, 'the model hook does not return route._prefetched');
-  assert.ok(_super.calledOnce, '_super is called');
+  assert.ok(_super.calledOnce, 'the super class\'s model hook is called');
 });
 
 test('the prefetched method returns the promise for the specified route', function(assert) {
@@ -82,4 +67,58 @@ test('the prefetched method returns the promise for the specified route', functi
 
   assert.equal(selfRoute.prefetched('parent')._result, parentData, 'prefetched returns the promise of the named route');
   assert.equal(selfRoute.prefetched()._result, selfData, 'prefetched returns the promise of the calling route when no name is given');
+});
+
+function modelHookTestingHelper(hook) {
+  const router = instance.lookup('router:main');
+
+  // simulate prefetch being defined
+  const obj = {};
+  const spy = this.stub().returns(obj);
+  const Route = classFromSpy(spy);
+  const route = typeof hook === 'function' ? Route.create({ prefetch: hook }) : Route.create();
+  const handlerInfoWithPrefetch = {
+    runSharedModelHook(_, hookName) {
+      if (hookName === 'prefetch') {
+        return Promise.resolve(this.handler.prefetch());
+      }
+    },
+    handler: route,
+  };
+  const transitionWithPrefetch = { handlerInfos: [handlerInfoWithPrefetch] };
+
+  router.trigger('willTransition', transitionWithPrefetch);
+
+  return {
+    route,
+    spy,
+    model: obj,
+  };
+}
+
+test('the model hook returns the result of prefetch if a prefetch hook is defined', function(assert) {
+  assert.expect(3);
+
+  const data = {};
+  function prefetch() {
+    return data;
+  }
+  const { model, route, spy: _super } = modelHookTestingHelper.call(this, prefetch);
+
+  return route.model().then((result) => {
+    assert.equal(result, data, 'the model hook returns a promise that resolves with the result of the prefetch hook');
+    assert.notEqual(result, model, 'the promise is not resolved the with result of the super class\'s model hook');
+    assert.notOk(_super.called, 'the super class\'s model hook is not called');
+  });
+});
+
+test('the model hook calls super if no prefetch hook is defined', function(assert) {
+  assert.expect(2);
+
+  const { model, route, spy: _super } = modelHookTestingHelper.call(this);
+
+  return route.model().then((result) => {
+    assert.equal(result, model, 'the model hook returns a promise that resolves with the result of the super class\'s model hook');
+    assert.ok(_super.called, 'the super class\'s model hook is called');
+  });
 });


### PR DESCRIPTION
It has always bothered me that the implementation of prefetch relies on certain private internals of RSVP Promises. This change removes that dependency.

/cc @nathanhammond @stefanpenner -- I'd love to get your input on this. It will break any routes that define both a prefetch hook that returns undefined and a model hook that calls `this._super`, but support for the ability to do that has never been explicitly stated, and my guess is it's a rare case (if used at all).
