### PR TITLE
Enable prefetch to work with async handlers

### DIFF
--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -2,8 +2,15 @@ import Ember from 'ember';
 import { initialize } from '../../../instance-initializers/prefetch';
 import { module } from 'qunit';
 import test from 'dummy/tests/ember-sinon-qunit/test';
+import wait from 'ember-test-helpers/wait';
+
+const { RSVP: { Promise } } = Ember;
 
 let application, instance;
+
+function scheduleMacroTask(task) {
+  setTimeout(task, 0);
+}
 
 module('Unit | Instance Initializer | prefetch', {
   beforeEach() {
@@ -28,7 +35,7 @@ test('the prefetch hook is invoked', function(assert) {
   initialize(instance);
 
   const router = instance.lookup('router:main');
-  const promise = new Ember.RSVP.resolve(1);
+  const promise = Promise.resolve(1);
   const runSharedModelHook = this.stub().returns(promise);
   const handler1 = {};
   const handler2 = {};
@@ -47,4 +54,85 @@ test('the prefetch hook is invoked', function(assert) {
   assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
   assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
   assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
+});
+
+test('the prefetch hook is invoked for async handlers', function(assert) {
+  assert.expect(4);
+
+  initialize(instance);
+
+  const router = instance.lookup('router:main');
+  const promise = Promise.resolve(1);
+  const runSharedModelHook = this.stub().returns(promise);
+  const handler1 = {};
+  const handler2 = {};
+  const handlerInfos = [{
+    runSharedModelHook,
+    handler: handler1,
+  }, {
+    runSharedModelHook,
+    handler: undefined,
+    handlerPromise: Promise.resolve(handler2)
+  }];
+  const transition = { handlerInfos };
+
+  router.trigger('willTransition', transition);
+
+  return wait().then(() => {
+    assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
+    assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
+    assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
+    assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
+  });
+});
+
+test('the prefetch hook is invoked according to route hierarchy for async handlers', function(assert) {
+  assert.expect(1);
+
+  initialize(instance);
+
+  const router = instance.lookup('router:main');
+  const operations = [];
+  const handler1 = {};
+  const handler2 = {};
+  const handler2Promise = new Promise((resolve) => {
+    scheduleMacroTask(() => {
+      operations.push('resolved handler 2');
+      resolve(handler2);
+    });
+  });
+  const handler1Promise = new Promise((resolve) => {
+    scheduleMacroTask(() => {
+      operations.push('resolved handler 1');
+      resolve(handler1);
+    });
+  });
+  const handlerInfos = [{
+    runSharedModelHook() {
+      operations.push('prefetch 1');
+    },
+    handler: undefined,
+    handlerPromise: handler1Promise
+  }, {
+    runSharedModelHook() {
+      operations.push('prefetch 2');
+    },
+    handler: undefined,
+    handlerPromise: handler2Promise
+  }];
+  const transition = { handlerInfos };
+
+  router.trigger('willTransition', transition);
+
+  return new Promise((resolve) => {
+    scheduleMacroTask(() => {
+      assert.deepEqual(operations, [
+        'resolved handler 2',
+        'resolved handler 1',
+        'prefetch 1',
+        'prefetch 2'
+      ]);
+      resolve();
+    });
+  });
 });

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -12,6 +12,7 @@ module('Unit | Mixin | route', {
     Ember.run(function() {
       application = Ember.Application.create();
       instance = application.buildInstance();
+      instance.setupRegistry();
       initialize(instance);
     });
   },


### PR DESCRIPTION
Addressing https://github.com/nickiaconis/ember-prefetch/issues/14.

We may want to wait until the outcome of https://github.com/tildeio/router.js/issues/193 is determined before merging, though the two changes should be relatively independent.

Note: would've added an acceptance test, but currently using an async `getHandler` method isn't possible without also changing some query params behavior (we're only doing this in lazy engines right now).
