### PR TITLE
Support Ember 2.4 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,17 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -6,7 +6,12 @@ export default function startApp(attrs) {
   let application;
 
   // use defaults, but you can override
-  let attributes = Ember.assign({}, config.APP, attrs);
+  let attributes;
+  if (typeof Ember.assign === 'function') {
+    attributes = Ember.assign({}, config.APP, attrs);
+  } else {
+    attributes = Ember.merge(Ember.merge({}, config.APP), attrs);
+  }
 
   Ember.run(() => {
     application = Application.create(attributes);

--- a/tests/unit/initializers/prefetch-test.js
+++ b/tests/unit/initializers/prefetch-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { initialize } from '../../../initializers/prefetch';
 import { module } from 'qunit';
-import test from 'dummy/tests/ember-sinon-qunit/test';
+import test from 'ember-sinon-qunit/test-support/test';
 
 var registry, application;
 

--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { initialize } from '../../../instance-initializers/prefetch';
 import { module } from 'qunit';
-import test from 'dummy/tests/ember-sinon-qunit/test';
+import test from 'ember-sinon-qunit/test-support/test';
 import wait from 'ember-test-helpers/wait';
 
 const { RSVP: { Promise } } = Ember;

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { initialize } from '../../../instance-initializers/prefetch';
 import RouteMixin from 'ember-prefetch/mixins/route';
 import { module } from 'qunit';
-import test from 'dummy/tests/ember-sinon-qunit/test';
+import test from 'ember-sinon-qunit/test-support/test';
 
 const { Promise } = Ember.RSVP;
 let application, instance;

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -12,7 +12,7 @@ module('Unit | Mixin | route', {
     Ember.run(function() {
       application = Ember.Application.create();
       instance = application.buildInstance();
-      instance.setupRegistry();
+      if (typeof instance.setupRegistry === 'function') { instance.setupRegistry(); }
       initialize(instance);
     });
   },


### PR DESCRIPTION
Fix support for Ember 2.4 LTS.
Also, resolve the warnings from  `ember-sinon-qunit`.