### PR TITLE
chore(package): update ember-cli-inject-live-reload to version 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-dependency-checker": "1.3.0",
     "ember-cli-htmlbars": "1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
-    "ember-cli-inject-live-reload": "1.4.1",
+    "ember-cli-inject-live-reload": "1.6.1",
     "ember-cli-jshint": "2.0.1",
     "ember-cli-qunit": "3.1.0",
     "ember-cli-release": "0.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,9 +1375,9 @@ ember-cli-htmlbars@1.1.1, ember-cli-htmlbars@^1.0.0:
     json-stable-stringify "^1.0.0"
     strip-bom "^2.0.0"
 
-ember-cli-inject-live-reload@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.4.1.tgz#ddadb9a346c5ed694ec0f9e11f49994eacafd277"
+ember-cli-inject-live-reload@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.6.1.tgz#82b8f5be454815a75e7f6d42c9ce0bc883a914a3"
 
 ember-cli-is-package-missing@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Closes #23

https://greenkeeper.io/