### PR TITLE
Fix Multiple Query Param Refresh

### DIFF
--- a/tests/acceptance/query-params-test.js
+++ b/tests/acceptance/query-params-test.js
@@ -44,6 +44,19 @@ test('loading a route with a query param marked with refreshModel runs the prefe
   });
 });
 
+test('loading a route with multiple query params marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit(`${QUERYPARAMS_ROUTE_URL}?fib=fab&fiz=baz`);
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fib=fab&fiz=baz', 'the query params are set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'queryparams\' prefetch hook was invoked');
+  });
+});
+
 test('transitioning to a route with a query param runs the prefetch hook', function(assert) {
   assert.expect(3);
 
@@ -74,6 +87,28 @@ test('transitioning to a route with a query param marked with refreshModel runs 
     const url = currentURL();
     assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
     assert.equal(url.substring(url.indexOf('?')), '?fiz=baz', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run');
+  });
+});
+
+test('transitioning to a route with multiple query params marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(() => {
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, {
+      queryParams: {
+        fib: 'fab',
+        fiz: 'baz',
+      },
+    });
+  });
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fib=fab&fiz=baz', 'the query params are set');
     assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run');
   });
 });
@@ -112,6 +147,31 @@ test('changing a query param marked with refreshModel runs the prefetch hook', f
     const url = currentURL();
     assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
     assert.equal(url.substring(url.indexOf('?')), '?fiz=baz', 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'the prefetch hook was run again');
+  });
+});
+
+test('changing multiple query params marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(4);
+
+  visit(`${QUERYPARAMS_ROUTE_URL}`);
+
+  andThen(() => {
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run for the initial transition');
+
+    this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, {
+      queryParams: {
+        foo: null,
+        fib: 'fab',
+        fiz: 'baz',
+      },
+    });
+  });
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fib=fab&fiz=baz', 'the query params are set');
     assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'the prefetch hook was run again');
   });
 });

--- a/tests/acceptance/query-params-test.js
+++ b/tests/acceptance/query-params-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 
+const QUERYPARAMS_HELPER_ROUTE_NAME = 'queryparams-helper';
 const QUERYPARAMS_ROUTE_NAME = 'queryparams';
 const QUERYPARAMS_ROUTE_URL = '/queryparams';
 
@@ -101,6 +102,28 @@ test('transitioning to a route with multiple query params marked with refreshMod
       queryParams: {
         fib: 'fab',
         fiz: 'baz',
+      },
+    });
+  });
+
+  andThen(() => {
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fib=fab&fiz=baz', 'the query params are set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run');
+  });
+});
+
+test('transitioning to a route with multiple query params marked with refreshModel that redirects to a route with multiple query params marked with refreshModel runs the prefetch hook', function(assert) {
+  assert.expect(3);
+
+  visit('/');
+
+  andThen(() => {
+    this.router.transitionTo(QUERYPARAMS_HELPER_ROUTE_NAME, {
+      queryParams: {
+        fix: 'fax',
+        fuzz: 'futz',
       },
     });
   });

--- a/tests/dummy/app/controllers/queryparams-helper.js
+++ b/tests/dummy/app/controllers/queryparams-helper.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: [
+    'fix',
+    'fuzz',
+  ],
+  fix: null,
+  fuzz: null,
+});

--- a/tests/dummy/app/controllers/queryparams.js
+++ b/tests/dummy/app/controllers/queryparams.js
@@ -1,7 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  queryParams: ['foo', 'fiz'],
+  queryParams: [
+    'foo',
+    'fib',
+    'fiz',
+  ],
   foo: null,
+  fib: null,
   fiz: null,
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('foo');
   this.route('bar');
   this.route('queryparams');
+  this.route('queryparams-helper');
 
   this.route('abort-transition-to-child', function() {
     this.route('child');

--- a/tests/dummy/app/routes/queryparams-helper.js
+++ b/tests/dummy/app/routes/queryparams-helper.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  queryParams: {
+    fix: {
+      refreshModel: true,
+    },
+    fuzz: {
+      refreshModel: true,
+    },
+  },
+
+  prefetch() {
+    this.replaceWith('queryparams', {
+      queryParams: {
+        fib: 'fab',
+        fiz: 'baz',
+      },
+    });
+  },
+});

--- a/tests/dummy/app/routes/queryparams.js
+++ b/tests/dummy/app/routes/queryparams.js
@@ -2,9 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   queryParams: {
+    fib: {
+      refreshModel: true,
+    },
     fiz: {
-      refreshModel: true
-    }
+      refreshModel: true,
+    },
   },
 
   prefetch() {


### PR DESCRIPTION
When more than one query param specified in the URL is configured with `refreshModel: true`, the transition passed to `willTransition` will be aborted before the prefetch hook is triggered.

This is caused by emberjs/ember.js#14597 and fixed by emberjs/ember.js#14607. This PR ports the fixed behavior to older versions of Ember.