### PR TITLE
Fix 2.13 deprecation of router.router rename

### DIFF
--- a/addon/initializers/redirect-patch.js
+++ b/addon/initializers/redirect-patch.js
@@ -40,7 +40,7 @@ export function initialize() {
           // always invoked for the routes in the new transition. Internally, the
           // `willTransition` hook uses `Ember.run.once` to fire the event, which
           // gurantees that it will not trigger `willTransition` multiple times.
-          if (stack.length === 1) {
+          if (stack.length === 1 && transition) {
             emberRouter.willTransition(latest.oldInfos, transition.state.handlerInfos, latest.transition);
             latest = null;
           }

--- a/addon/initializers/redirect-patch.js
+++ b/addon/initializers/redirect-patch.js
@@ -13,7 +13,9 @@ export function initialize() {
         this._super.apply(this, arguments);
 
         // now this.router is available
-        const router = this.router;
+        // router.router renamed to _routerMicrolib in 2.13
+        // https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib
+        const router = this._routerMicrolib || this.router;
         const emberRouter = this;
 
         // replace router's transitionByIntent method, through which all transitions pass


### PR DESCRIPTION
https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib