### PR TITLE
Fix private APIs that are about to go away

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ matrix:
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
-before_script:
-  - node_modules/bower/bin/bower install
-
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -67,8 +67,9 @@ function runHook(hookName, handlerInfo, transition, args) {
     `runSharedModelHook` was deleted as part of an internal cleanup
     and is now moved to a function much like this one. This detects
     if the `runSharedModelHook` exists or not.
-  */
-  if (handlerInfo.runSharedModelHook === undefined) {
+    */
+   if (handlerInfo.runSharedModelHook === undefined) {
+    // This branch will be taken if the version of router_js is >= 2.0.0.
     if (handlerInfo.handler !== undefined && handlerInfo.handler[hookName] !== undefined) {
       if (handlerInfo.queryParams !== undefined) {
         args.push(handlerInfo.queryParams);
@@ -90,6 +91,7 @@ function runHook(hookName, handlerInfo, transition, args) {
       return Ember.RSVP.resolve(result);
     }
   } else {
+    // This branch will be taken router_js that is < 2.0.0.
     return handlerInfo.runSharedModelHook(transition, hookName, args);
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,0 @@
-{
-  "name": "ember-prefetch",
-  "dependencies": {}
-}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-sinon": "0.7.0",
     "ember-sinon-qunit": "1.6.0",
     "ember-source": "2.13.3",
+    "ember-try": "^0.2.23",
     "loader.js": "4.5.1"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,6 +2466,32 @@ ember-try-config@^2.0.1:
     rsvp "^3.2.1"
     semver "^5.1.0"
 
+ember-try-config@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-try-config/-/ember-try-config-2.2.0.tgz#6be0af6c71949813e02ac793564fddbf8336b807"
+  dependencies:
+    lodash "^4.6.1"
+    node-fetch "^1.3.3"
+    rsvp "^3.2.1"
+    semver "^5.1.0"
+
+ember-try@^0.2.23:
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.23.tgz#39b57141b4907541d0ac8b503d211e6946b08718"
+  dependencies:
+    chalk "^1.0.0"
+    cli-table2 "^0.2.0"
+    core-object "^1.1.0"
+    debug "^2.2.0"
+    ember-try-config "^2.2.0"
+    extend "^3.0.0"
+    fs-extra "^0.26.0"
+    promise-map-series "^0.2.1"
+    resolve "^1.1.6"
+    rimraf "^2.3.2"
+    rsvp "^3.0.17"
+    semver "^5.1.0"
+
 ember-try@^0.2.6:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.8.tgz#5f135d23d83561dc8dfb4a4d998420b69b740acd"


### PR DESCRIPTION
This inlines the mechanics of what `runSharedModelHook` was doing. It no longer exists in router.js.