### PR TITLE
Remove all deprecations and majority of private API usage

### DIFF
--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -1,0 +1,118 @@
+import { assign } from '@ember/polyfills';
+import { gte } from 'ember-compatibility-helpers';
+
+export let qpsChanged;
+export let shouldRefreshModel;
+export let pathsDiffer;
+export let paramsDiffer;
+export let createPrefetchChangeSet;
+
+if (gte('3.6.0')) {
+  function createList(enumerable) { // eslint-disable-line no-inner-declarations
+    let out = [];
+
+    if (enumerable === null) return out;
+
+    enumerable.find(item => {
+      out.push(item)
+    });
+    return out;
+  }
+
+  qpsChanged = function _qpsChanged(from, to) {
+    let fromQps = Object.keys(from.queryParams).sort();
+    let toQps = Object.keys(to.queryParams).sort();
+
+    if (fromQps.length !== toQps.length) return true;
+
+    return !toQps.every((qp, i)=> {
+      return fromQps[i] === qp && to.queryParams[qp] === from.queryParams[qp];
+    });
+  }
+
+  shouldRefreshModel = function _shouldRefreshModel(routeQueryParams, infoQueryParams) {
+    let routeQPKeys = Object.keys(routeQueryParams);
+    let infoQPKeys = Object.keys(infoQueryParams);
+    return routeQPKeys.some(key => {
+      return routeQueryParams[key].refreshModel && infoQPKeys.indexOf(key) > -1;
+    });
+  }
+
+  function paramsMatch(from, to) { // eslint-disable-line no-inner-declarations
+    return to.paramNames.every((paramName, i) => {
+      return from.paramNames[i] === paramName && from.params[paramName] === to.params[paramName];
+    });
+  }
+
+  pathsDiffer = function _pathsDiffer(from, to) {
+    return !to.every((info, i) => {
+      return info.name === from[i].name;
+    })
+  }
+
+
+  paramsDiffer = function _paramsDiffer(from, to) {
+    return !to.every((info, i) => {
+      let _from = from[i];
+      let _to = info;
+      return _to.paramNames.length === _from.paramNames.length && paramsMatch(_from, _to)
+    });
+  }
+
+  function qpsDiffer(privateRouter, to, transition) { // eslint-disable-line no-inner-declarations
+    let routes = getPrefetched(privateRouter, to);
+    if (transition.from === null) {
+      return { shouldCall: true, for: routes };
+    }
+
+    if (qpsChanged(transition.from, transition.to)) {
+      let prefetchRoutes = [];
+
+      routes.forEach((info) => {
+        let { route } = info;
+        if (shouldRefreshModel(route.queryParams, transition.to.queryParams)) {
+          prefetchRoutes.push(info);
+        }
+      });
+
+      return { shouldCall: true, for: prefetchRoutes };
+    }
+
+    return { shouldCall: false, for: [] };
+  }
+
+  function getPrefetched(privateRouter, to) { // eslint-disable-line no-inner-declarations
+    let routes = [];
+    for (let i = 0; i < to.length; i++) {
+      let info = to[i];
+      let route = privateRouter.getRoute(info.name);
+      if (route !== undefined && route !== null) {
+        routes.push({ route, fullParms: assign({}, info.params, { queryParams: info.queryParams }) });
+      }
+    }
+
+    return routes;
+  }
+
+  createPrefetchChangeSet = function _createPrefetchChangeSet(privateRouter, transition) {
+    let toList = createList(transition.to);
+    let fromList = createList(transition.from);
+
+    // Paths Changed
+    if (toList.length > fromList.length) {
+      return { shouldCall: true, for: getPrefetched(privateRouter, toList) };
+    }
+
+    if (pathsDiffer(fromList, toList)) {
+      return { shouldCall: true, for: getPrefetched(privateRouter, toList) };
+    }
+
+    // Params Changed
+    if (paramsDiffer(fromList, toList)) {
+      return { shouldCall: true, for: getPrefetched(privateRouter, toList) };
+    }
+
+    // Query Params changed
+    return qpsDiffer(privateRouter, toList, transition);
+  }
+}

--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -8,18 +8,21 @@ export let paramsDiffer;
 export let createPrefetchChangeSet;
 
 if (gte('3.6.0')) {
+  // remove guard for Ember 3.8 LTS and rev major
   function createList(enumerable) { // eslint-disable-line no-inner-declarations
     let out = [];
 
     if (enumerable === null) return out;
 
     enumerable.find(item => {
-      out.push(item)
+      out.push(item);
+      // using `find` to emulate forEach
+      return false;
     });
     return out;
   }
 
-  qpsChanged = function _qpsChanged(from, to) {
+  qpsChanged = function(from, to) {
     let fromQps = Object.keys(from.queryParams).sort();
     let toQps = Object.keys(to.queryParams).sort();
 
@@ -30,7 +33,7 @@ if (gte('3.6.0')) {
     });
   }
 
-  shouldRefreshModel = function _shouldRefreshModel(routeQueryParams, infoQueryParams) {
+  shouldRefreshModel = function(routeQueryParams, infoQueryParams) {
     let routeQPKeys = Object.keys(routeQueryParams);
     let infoQPKeys = Object.keys(infoQueryParams);
     return routeQPKeys.some(key => {
@@ -44,14 +47,13 @@ if (gte('3.6.0')) {
     });
   }
 
-  pathsDiffer = function _pathsDiffer(from, to) {
+  pathsDiffer = function(from, to) {
     return !to.every((info, i) => {
       return info.name === from[i].name;
     })
   }
 
-
-  paramsDiffer = function _paramsDiffer(from, to) {
+  paramsDiffer = function(from, to) {
     return !to.every((info, i) => {
       let _from = from[i];
       let _to = info;
@@ -87,19 +89,19 @@ if (gte('3.6.0')) {
       let info = to[i];
       let route = privateRouter.getRoute(info.name);
       if (route !== undefined && route !== null) {
-        routes.push({ route, fullParms: assign({}, info.params, { queryParams: info.queryParams }) });
+        routes.push({ route, fullParams: assign({}, info.params, { queryParams: info.queryParams }) });
       }
     }
 
     return routes;
   }
 
-  createPrefetchChangeSet = function _createPrefetchChangeSet(privateRouter, transition) {
+  createPrefetchChangeSet = function(privateRouter, transition) {
     let toList = createList(transition.to);
     let fromList = createList(transition.from);
 
     // Paths Changed
-    if (toList.length > fromList.length) {
+    if (toList.length !== fromList.length) {
       return { shouldCall: true, for: getPrefetched(privateRouter, toList) };
     }
 

--- a/addon/initializers/redirect-patch.js
+++ b/addon/initializers/redirect-patch.js
@@ -4,7 +4,7 @@ import { lte } from 'ember-compatibility-helpers';
 let hasInitialized = false;
 
 export function initialize() {
-  if (lte('3.5.1')) {
+  if (lte('3.5.1')) { // Delete all of this in the Ember 3.8 LTS and rev major
     if (!hasInitialized) {
       hasInitialized = true;
 

--- a/addon/initializers/redirect-patch.js
+++ b/addon/initializers/redirect-patch.js
@@ -1,56 +1,59 @@
 import EmberRouter from '@ember/routing/router';
+import { lte } from 'ember-compatibility-helpers';
 
 let hasInitialized = false;
 
 export function initialize() {
-  if (!hasInitialized) {
-    hasInitialized = true;
+  if (lte('3.5.1')) {
+    if (!hasInitialized) {
+      hasInitialized = true;
 
-    EmberRouter.reopen({
-      _initRouterJs() {
-        this._super.apply(this, arguments);
+      EmberRouter.reopen({
+        _initRouterJs() {
+          this._super.apply(this, arguments);
 
-        // now this.router is available
-        // router.router renamed to _routerMicrolib in 2.13
-        // https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib
-        const router = this._routerMicrolib || this.router;
-        const emberRouter = this;
-        const stack = [];
-        let latest = null;
+          // now this.router is available
+          // router.router renamed to _routerMicrolib in 2.13
+          // https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib
+          const router = this._routerMicrolib || this.router;
+          const emberRouter = this;
+          const stack = [];
+          let latest = null;
 
-        // replace router's transitionByIntent method, through which all transitions pass
-        const oldTransitionByIntent = router.transitionByIntent;
-        router.transitionByIntent = function() {
-          stack.push(1);
+          // replace router's transitionByIntent method, through which all transitions pass
+          const oldTransitionByIntent = router.transitionByIntent;
+          router.transitionByIntent = function() {
+            stack.push(1);
 
-          const oldInfos = router.state.handlerInfos;
-          const transition = oldTransitionByIntent.apply(router, arguments);
+            const oldInfos = router.state.handlerInfos;
+            const transition = oldTransitionByIntent.apply(router, arguments);
 
-          if (!latest || stack.length >= latest.stackSize) {
-            latest = {
-              oldInfos,
-              transition,
-            };
-          }
+            if (!latest || stack.length >= latest.stackSize) {
+              latest = {
+                oldInfos,
+                transition,
+              };
+            }
 
-          latest.stackSize = stack.length;
+            latest.stackSize = stack.length;
 
-          // Router.js does not trigger `willTransition` when redirecting. We need
-          // `willTransition` to be triggered regardless so that the `prefetch` hook is
-          // always invoked for the routes in the new transition. Internally, the
-          // `willTransition` hook uses `Ember.run.once` to fire the event, which
-          // gurantees that it will not trigger `willTransition` multiple times.
-          if (stack.length === 1 && transition) {
-            emberRouter.willTransition(latest.oldInfos, transition.state.handlerInfos, latest.transition);
-            latest = null;
-          }
+            // Router.js does not trigger `willTransition` when redirecting. We need
+            // `willTransition` to be triggered regardless so that the `prefetch` hook is
+            // always invoked for the routes in the new transition. Internally, the
+            // `willTransition` hook uses `Ember.run.once` to fire the event, which
+            // gurantees that it will not trigger `willTransition` multiple times.
+            if (stack.length === 1 && transition) {
+              emberRouter.willTransition(latest.oldInfos, transition.state.handlerInfos, latest.transition);
+              latest = null;
+            }
 
-          stack.pop();
+            stack.pop();
 
-          return transition;
-        };
-      },
-    });
+            return transition;
+          };
+        },
+      });
+    }
   }
 }
 

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -1,103 +1,108 @@
 import { assign } from '@ember/polyfills';
 import { resolve } from 'rsvp';
+import { gte } from 'ember-compatibility-helpers';
 
 export function initialize(instance) {
-  const ROUTER_NAME = 'router:main';
-  const router = (typeof instance.lookup === 'function' ? instance.lookup(ROUTER_NAME) : instance.container.lookup(ROUTER_NAME));
+  if (gte('3.6.0')) {
+    instance.inject('route:application', '__prefetch', 'service:prefetch');
+  } else {
+    const ROUTER_NAME = 'router:main';
+    const router = (typeof instance.lookup === 'function' ? instance.lookup(ROUTER_NAME) : instance.container.lookup(ROUTER_NAME));
 
-  router.on('willTransition', function(transition) {
-    if (!transition.handlerInfos) {
-      return;
-    }
-
-    const pivotHandler = transition.pivotHandler;
-
-    // If there is no pivot, we should try to prefetch all handlers.
-    let hasSeenPivot = pivotHandler == null ? true : false;
-
-    // For asynchronously loaded handlers, we chain them to ensure
-    // resolution order.
-    let handlerPromiseChain = resolve();
-    transition.handlerInfos.forEach(function(handlerInfo) {
-      // Bail if we're tearing down
-      if ((handlerInfo.handler && handlerInfo.handler.isDestroying === true) || router.isDestroying === true) {
+    router.on('willTransition', function(transition) {
+      if (!transition.handlerInfos) {
         return;
       }
 
-      // Don't prefetch handlers above the pivot.
-      if (!hasSeenPivot || transition.isAborted) {
-        // The pivot is the first common ancestor, so it is skipped as well.
-        if (handlerInfo.handler === pivotHandler) {
-          hasSeenPivot = true;
+      const pivotHandler = transition.pivotHandler;
+
+      // If there is no pivot, we should try to prefetch all handlers.
+      let hasSeenPivot = pivotHandler == null ? true : false;
+
+      // For asynchronously loaded handlers, we chain them to ensure
+      // resolution order.
+      let handlerPromiseChain = resolve();
+      transition.handlerInfos.forEach(function(handlerInfo) {
+        // Bail if we're tearing down
+        if ((handlerInfo.handler && handlerInfo.handler.isDestroying === true) || router.isDestroying === true) {
+          return;
         }
 
-        return;
-      }
+        // Don't prefetch handlers above the pivot.
+        if (!hasSeenPivot || transition.isAborted) {
+          // The pivot is the first common ancestor, so it is skipped as well.
+          if (handlerInfo.handler === pivotHandler) {
+            hasSeenPivot = true;
+          }
 
-      // Skip handlers that have been provided a model.
-      if (handlerInfo.context != null) {
-        return;
-      }
+          return;
+        }
 
-      // Build fullParams as in unresolved-handler-info-by-param#getModel.
-      let fullParams = handlerInfo.params || {};
-      if (transition && transition.queryParams) {
-        fullParams = assign({}, fullParams);
-        fullParams.queryParams = transition.queryParams;
-      }
+        // Skip handlers that have been provided a model.
+        if (handlerInfo.context != null) {
+          return;
+        }
 
-      // Run the prefetch hook if the route has one.
-      if (!handlerInfo.handler && handlerInfo.handlerPromise) {
-        handlerPromiseChain = handlerPromiseChain.then(() => (
-          handlerInfo.handlerPromise.then((handler) => {
-            if (handler.isDestroying === true) {
-              return;
-            }
-            handler._prefetched = runHook('prefetch', handlerInfo, transition, [fullParams]);
-          })
-        ));
-      } else {
-        handlerInfo.handler._prefetched = runHook('prefetch', handlerInfo, transition, [fullParams]);
-      }
+        // Build fullParams as in unresolved-handler-info-by-param#getModel.
+        let fullParams = handlerInfo.params || {};
+        if (transition && transition.queryParams) {
+          fullParams = assign({}, fullParams);
+          fullParams.queryParams = transition.queryParams;
+        }
+
+        // Run the prefetch hook if the route has one.
+        if (!handlerInfo.handler && handlerInfo.handlerPromise) {
+          handlerPromiseChain = handlerPromiseChain.then(() => (
+            handlerInfo.handlerPromise.then((handler) => {
+              if (handler.isDestroying === true) {
+                return;
+              }
+              handler._prefetched = runHook('prefetch', handlerInfo, transition, [fullParams]);
+            })
+          ));
+        } else {
+          handlerInfo.handler._prefetched = runHook('prefetch', handlerInfo, transition, [fullParams]);
+        }
+      });
     });
-  });
-}
 
-function runHook(hookName, handlerInfo, transition, args) {
-  /*
-    `runSharedModelHook` was deleted as part of an internal cleanup
-    and is now moved to a function much like this one. This detects
-    if the `runSharedModelHook` exists or not.
-    */
-   if (handlerInfo.runSharedModelHook === undefined) {
-    // This branch will be taken if the version of router_js is >= 2.0.0.
-    if (handlerInfo.handler !== undefined && handlerInfo.handler[hookName] !== undefined) {
-      if (handlerInfo.queryParams !== undefined) {
-        args.push(handlerInfo.queryParams);
+    function runHook(hookName, handlerInfo, transition, args) { // eslint-disable-line no-inner-declarations
+      /*
+        `runSharedModelHook` was deleted as part of an internal cleanup
+        and is now moved to a function much like this one. This detects
+        if the `runSharedModelHook` exists or not.
+        */
+       if (handlerInfo.runSharedModelHook === undefined) {
+        // This branch will be taken if the version of router_js is >= 2.0.0.
+        if (handlerInfo.handler !== undefined && handlerInfo.handler[hookName] !== undefined) {
+          if (handlerInfo.queryParams !== undefined) {
+            args.push(handlerInfo.queryParams);
+          }
+
+          args.push(transition);
+
+          let result;
+          if (handlerInfo.handler[`_${hookName}`] !== undefined) {
+            result = handlerInfo.handler[`_${hookName}`](...args);
+          } else if (handlerInfo.handler[hookName] !== undefined) {
+            result = handlerInfo.handler[hookName](...args);
+          }
+
+          if (result !== undefined && result.isTransition) {
+            result = null;
+          }
+
+          return resolve(result);
+        }
+      } else {
+        // This branch will be taken router_js that is < 2.0.0.
+        return handlerInfo.runSharedModelHook(transition, hookName, args);
       }
-
-      args.push(transition);
-
-      let result;
-      if (handlerInfo.handler[`_${hookName}`] !== undefined) {
-        result = handlerInfo.handler[`_${hookName}`](...args);
-      } else if (handlerInfo.handler[hookName] !== undefined) {
-        result = handlerInfo.handler[hookName](...args);
-      }
-
-      if (result !== undefined && result.isTransition) {
-        result = null;
-      }
-
-      return resolve(result);
     }
-  } else {
-    // This branch will be taken router_js that is < 2.0.0.
-    return handlerInfo.runSharedModelHook(transition, hookName, args);
   }
 }
 
 export default {
   name: 'prefetch',
-  initialize: initialize
+  initialize
 };

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -8,7 +8,7 @@ export function initialize(instance) {
   } else {
     // Delete all of this in the Ember 3.8 LTS and rev major
     const ROUTER_NAME = 'router:main';
-    const router = (typeof instance.lookup === 'function' ? instance.lookup(ROUTER_NAME) : instance.container.lookup(ROUTER_NAME));
+    const router =instance.lookup(ROUTER_NAME);
 
     router.on('willTransition', function(transition) {
       if (!transition.handlerInfos) {

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -6,6 +6,7 @@ export function initialize(instance) {
   if (gte('3.6.0')) {
     instance.inject('route:application', '__prefetch', 'service:prefetch');
   } else {
+    // Delete all of this in the Ember 3.8 LTS and rev major
     const ROUTER_NAME = 'router:main';
     const router = (typeof instance.lookup === 'function' ? instance.lookup(ROUTER_NAME) : instance.container.lookup(ROUTER_NAME));
 

--- a/addon/services/prefetch.js
+++ b/addon/services/prefetch.js
@@ -1,0 +1,45 @@
+import Service, { inject as service } from '@ember/service';
+import { schedule } from '@ember/runloop';
+import { createPrefetchChangeSet } from '../-private/diff-route-info';
+import RSVP from 'rsvp';
+import { gte } from 'ember-compatibility-helpers';
+
+let PrefetchService;
+
+if (gte('3.6.0')) {
+  PrefetchService = Service.extend({
+    router: service('router'),
+    init() {
+      this._super(...arguments);
+      let privateRouter = this.router._router._routerMicrolib;
+      let seenRoutes = new WeakMap();
+
+      this.router.on('routeWillChange', transition => {
+        if (transition.to && /(^|_|\.)(loading$|error$)/.test(transition.to.name)) {
+          return;
+        }
+
+        schedule('actions', () => {
+          let changeSet = createPrefetchChangeSet(privateRouter, transition);
+          if (changeSet.shouldCall) {
+            for (let i = 0; i < changeSet.for.length; i++) {
+              let { route, fullParms } = changeSet.for[i];
+              if (seenRoutes.has(route)) continue;
+
+                let result = route.prefetch(fullParms, transition);
+                route._prefetched = RSVP.resolve(result);
+                seenRoutes.set(route, true);
+                if (transition.isAborted) return;
+            }
+          }
+        });
+      });
+
+      this.router.on('routeDidChange', () => {
+        seenRoutes = new WeakMap();
+      });
+    }
+  });
+}
+
+export default PrefetchService;

--- a/app/services/prefetch.js
+++ b/app/services/prefetch.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-prefetch/services/prefetch';

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "test": "tests"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.1.2"
+    "ember-cli-babel": "^7.1.2",
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/initializers/prefetch-test.js
+++ b/tests/unit/initializers/prefetch-test.js
@@ -5,37 +5,40 @@ import { run } from '@ember/runloop';
 import { initialize } from '../../../initializers/prefetch';
 import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import { lte } from 'ember-compatibility-helpers';
 
 
-var registry, application;
+if (lte('3.5.1')) {
+  var registry, application;
 
-module('Unit | Initializer | prefetch', function(hooks) {
-  hooks.beforeEach(function() {
-    run(function() {
-      application = Application.create();
-      registry = application.registry;
-      application.deferReadiness();
+  module('Unit | Initializer | prefetch', function(hooks) {
+    hooks.beforeEach(function() {
+      run(function() {
+        application = Application.create();
+        registry = application.registry;
+        application.deferReadiness();
+      });
+    });
+
+    hooks.afterEach(function() {
+      run(function() {
+        registry = null;
+        application.destroy();
+        application = null;
+      });
+    });
+
+    test('an Ember#Route\'s default model hook returns its prefetched property', function(assert) {
+      assert.expect(1);
+
+      initialize(registry, application);
+
+      const data = {};
+      const route = Route.create({ _prefetched: EmberPromise.resolve(data) });
+
+      return route.model().then((model) => {
+        assert.equal(model, data, 'the model hook returns prefetched');
+      });
     });
   });
-
-  hooks.afterEach(function() {
-    run(function() {
-      registry = null;
-      application.destroy();
-      application = null;
-    });
-  });
-
-  test('an Ember#Route\'s default model hook returns its prefetched property', function(assert) {
-    assert.expect(1);
-
-    initialize(registry, application);
-
-    const data = {};
-    const route = Route.create({ _prefetched: EmberPromise.resolve(data) });
-
-    return route.model().then((model) => {
-      assert.equal(model, data, 'the model hook returns prefetched');
-    });
-  });
-});
+}

--- a/tests/unit/instance-initializers/prefetch-test.js
+++ b/tests/unit/instance-initializers/prefetch-test.js
@@ -5,136 +5,139 @@ import { initialize } from '../../../instance-initializers/prefetch';
 import { module } from 'qunit';
 import { settled } from '@ember/test-helpers';
 import test from 'ember-sinon-qunit/test-support/test';
+import { lte } from 'ember-compatibility-helpers';
 
 
-let application, instance;
+if (lte('3.5.1')) {
+  let application, instance;
 
-function scheduleMacroTask(task) {
-  setTimeout(task, 0);
-}
+  function scheduleMacroTask(task) { // eslint-disable-line no-inner-declarations
+    setTimeout(task, 0);
+  }
 
-module('Unit | Instance Initializer | prefetch', function(hooks) {
-  hooks.beforeEach(function() {
-    run(function() {
-      application = Application.create();
-      instance = application.buildInstance();
+  module('Unit | Instance Initializer | prefetch', function(hooks) {
+    hooks.beforeEach(function() {
+      run(function() {
+        application = Application.create();
+        instance = application.buildInstance();
+      });
     });
-  });
 
-  hooks.afterEach(function() {
-    run(function() {
-      application.destroy();
-      application = null;
-      instance.destroy();
-      instance = null;
+    hooks.afterEach(function() {
+      run(function() {
+        application.destroy();
+        application = null;
+        instance.destroy();
+        instance = null;
+      });
     });
-  });
 
-  test('the prefetch hook is invoked', function(assert) {
-    assert.expect(4);
+    test('the prefetch hook is invoked', function(assert) {
+      assert.expect(4);
 
-    initialize(instance);
+      initialize(instance);
 
-    const router = instance.lookup('router:main');
-    const promise = Promise.resolve(1);
-    const runSharedModelHook = this.stub().returns(promise);
-    const handler1 = {};
-    const handler2 = {};
-    const handlerInfos = [{
-      runSharedModelHook,
-      handler: handler1,
-    }, {
-      runSharedModelHook,
-      handler: handler2,
-    }];
-    const transition = { handlerInfos };
+      const router = instance.lookup('router:main');
+      const promise = Promise.resolve(1);
+      const runSharedModelHook = this.stub().returns(promise);
+      const handler1 = {};
+      const handler2 = {};
+      const handlerInfos = [{
+        runSharedModelHook,
+        handler: handler1,
+      }, {
+        runSharedModelHook,
+        handler: handler2,
+      }];
+      const transition = { handlerInfos };
 
-    router.trigger('willTransition', transition);
+      router.trigger('willTransition', transition);
 
-    assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
-    assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
-    assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
-    assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
-  });
-
-  test('the prefetch hook is invoked for async handlers', function(assert) {
-    assert.expect(4);
-
-    initialize(instance);
-
-    const router = instance.lookup('router:main');
-    const promise = Promise.resolve(1);
-    const runSharedModelHook = this.stub().returns(promise);
-    const handler1 = {};
-    const handler2 = {};
-    const handlerInfos = [{
-      runSharedModelHook,
-      handler: handler1,
-    }, {
-      runSharedModelHook,
-      handler: undefined,
-      handlerPromise: Promise.resolve(handler2)
-    }];
-    const transition = { handlerInfos };
-
-    router.trigger('willTransition', transition);
-
-    return settled().then(() => {
       assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
       assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
       assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
       assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
     });
+
+    test('the prefetch hook is invoked for async handlers', function(assert) {
+      assert.expect(4);
+
+      initialize(instance);
+
+      const router = instance.lookup('router:main');
+      const promise = Promise.resolve(1);
+      const runSharedModelHook = this.stub().returns(promise);
+      const handler1 = {};
+      const handler2 = {};
+      const handlerInfos = [{
+        runSharedModelHook,
+        handler: handler1,
+      }, {
+        runSharedModelHook,
+        handler: undefined,
+        handlerPromise: Promise.resolve(handler2)
+      }];
+      const transition = { handlerInfos };
+
+      router.trigger('willTransition', transition);
+
+      return settled().then(() => {
+        assert.ok(runSharedModelHook.calledTwice, 'handlerInfo.runSharedModelHook is called once per handlerInfo');
+        assert.ok(runSharedModelHook.calledWith(transition, 'prefetch'), 'handlerInfo.runSharedModelHook is called with the transition and "prefetch"');
+        assert.equal(handler1._prefetched, promise, 'the promise is set on handler1 as _prefetched');
+        assert.equal(handler2._prefetched, promise, 'the promise is set on handler2 as _prefetched');
+      });
+    });
+
+    test('the prefetch hook is invoked according to route hierarchy for async handlers', function(assert) {
+      assert.expect(1);
+
+      initialize(instance);
+
+      const router = instance.lookup('router:main');
+      const operations = [];
+      const handler1 = {};
+      const handler2 = {};
+      const handler2Promise = new Promise((resolve) => {
+        scheduleMacroTask(() => {
+          operations.push('resolved handler 2');
+          resolve(handler2);
+        });
+      });
+      const handler1Promise = new Promise((resolve) => {
+        scheduleMacroTask(() => {
+          operations.push('resolved handler 1');
+          resolve(handler1);
+        });
+      });
+      const handlerInfos = [{
+        runSharedModelHook() {
+          operations.push('prefetch 1');
+        },
+        handler: undefined,
+        handlerPromise: handler1Promise
+      }, {
+        runSharedModelHook() {
+          operations.push('prefetch 2');
+        },
+        handler: undefined,
+        handlerPromise: handler2Promise
+      }];
+      const transition = { handlerInfos };
+
+      router.trigger('willTransition', transition);
+
+      return new Promise((resolve) => {
+        scheduleMacroTask(() => {
+          assert.deepEqual(operations, [
+            'resolved handler 2',
+            'resolved handler 1',
+            'prefetch 1',
+            'prefetch 2'
+          ]);
+          resolve();
+        });
+      });
+    });
   });
-
-  test('the prefetch hook is invoked according to route hierarchy for async handlers', function(assert) {
-    assert.expect(1);
-
-    initialize(instance);
-
-    const router = instance.lookup('router:main');
-    const operations = [];
-    const handler1 = {};
-    const handler2 = {};
-    const handler2Promise = new Promise((resolve) => {
-      scheduleMacroTask(() => {
-        operations.push('resolved handler 2');
-        resolve(handler2);
-      });
-    });
-    const handler1Promise = new Promise((resolve) => {
-      scheduleMacroTask(() => {
-        operations.push('resolved handler 1');
-        resolve(handler1);
-      });
-    });
-    const handlerInfos = [{
-      runSharedModelHook() {
-        operations.push('prefetch 1');
-      },
-      handler: undefined,
-      handlerPromise: handler1Promise
-    }, {
-      runSharedModelHook() {
-        operations.push('prefetch 2');
-      },
-      handler: undefined,
-      handlerPromise: handler2Promise
-    }];
-    const transition = { handlerInfos };
-
-    router.trigger('willTransition', transition);
-
-    return new Promise((resolve) => {
-      scheduleMacroTask(() => {
-        assert.deepEqual(operations, [
-          'resolved handler 2',
-          'resolved handler 1',
-          'prefetch 1',
-          'prefetch 2'
-        ]);
-        resolve();
-      });
-    });
-  });
-});
+}

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -6,123 +6,126 @@ import { initialize } from '../../../instance-initializers/prefetch';
 import RouteMixin from 'ember-prefetch/mixins/route';
 import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import { lte } from 'ember-compatibility-helpers';
 
-let application, instance;
+if (lte('3.5.1')) {
+  let application, instance;
 
-module('Unit | Mixin | route', function(hooks) {
-  hooks.beforeEach(function() {
-    run(function() {
-      application = Application.create();
-      instance = application.buildInstance();
-      if (typeof instance.setupRegistry === 'function') { instance.setupRegistry(); }
-      initialize(instance);
+  module('Unit | Mixin | route', function(hooks) {
+    hooks.beforeEach(function() {
+      run(function() {
+        application = Application.create();
+        instance = application.buildInstance();
+        if (typeof instance.setupRegistry === 'function') { instance.setupRegistry(); }
+        initialize(instance);
+      });
     });
-  });
 
-  hooks.afterEach(function() {
-    run(function() {
-      application.destroy();
-      application = null;
-      instance.destroy();
-      instance = null;
+    hooks.afterEach(function() {
+      run(function() {
+        application.destroy();
+        application = null;
+        instance.destroy();
+        instance = null;
+      });
     });
-  });
 
-  function classFromObject(obj) {
-    return EmberObject.extend(obj, RouteMixin);
-  }
-
-  function classFromSpy(spy) {
-    return classFromObject({
-      model: spy,
-    });
-  }
-
-  function registerRoute(name, obj) {
-    obj.routeName = obj.routeName || name;
-    const longName = `route:${name}`;
-    instance.register(longName, classFromObject(obj));
-    return instance.lookup(longName);
-  }
-
-  test('the case when route._prefetched is undefined is accounted for', function(assert) {
-    assert.expect(1);
-
-    const _super = this.spy();
-    const route = classFromSpy(_super).create();
-    try {
-      route.model();
-    } catch(e) {
-      assert.ok(false, 'the model hook doesn\'t die with route._prefetched is undefined');
+    function classFromObject(obj) {
+      return EmberObject.extend(obj, RouteMixin);
     }
 
-    assert.ok(_super.calledOnce, 'the super class\'s model hook is called');
-  });
-
-  test('the prefetched method returns the promise for the specified route', function(assert) {
-    assert.expect(2);
-
-    const parentData = {};
-    registerRoute('parent', { _prefetched: parentData });
-
-    const selfData = {};
-    const selfRoute = registerRoute('self', { _prefetched: selfData });
-
-    assert.equal(selfRoute.prefetched('parent')._result, parentData, 'prefetched returns the promise of the named route');
-    assert.equal(selfRoute.prefetched()._result, selfData, 'prefetched returns the promise of the calling route when no name is given');
-  });
-
-  function modelHookTestingHelper(hook) {
-    const router = instance.lookup('router:main');
-
-    // simulate prefetch being defined
-    const obj = {};
-    const spy = this.stub().returns(obj);
-    const Route = classFromSpy(spy);
-    const route = typeof hook === 'function' ? Route.create({ prefetch: hook }) : Route.create();
-    const handlerInfoWithPrefetch = {
-      runSharedModelHook(_, hookName) {
-        if (hookName === 'prefetch') {
-          return Promise.resolve(this.handler.prefetch());
-        }
-      },
-      handler: route,
-    };
-    const transitionWithPrefetch = { handlerInfos: [handlerInfoWithPrefetch] };
-
-    router.trigger('willTransition', transitionWithPrefetch);
-
-    return {
-      route,
-      spy,
-      model: obj,
-    };
-  }
-
-  test('the model hook returns the result of prefetch if a prefetch hook is defined', function(assert) {
-    assert.expect(3);
-
-    const data = {};
-    function prefetch() {
-      return data;
+    function classFromSpy(spy) {
+      return classFromObject({
+        model: spy,
+      });
     }
-    const { model, route, spy: _super } = modelHookTestingHelper.call(this, prefetch);
 
-    return route.model().then((result) => {
-      assert.equal(result, data, 'the model hook returns a promise that resolves with the result of the prefetch hook');
-      assert.notEqual(result, model, 'the promise is not resolved the with result of the super class\'s model hook');
-      assert.notOk(_super.called, 'the super class\'s model hook is not called');
+    function registerRoute(name, obj) {
+      obj.routeName = obj.routeName || name;
+      const longName = `route:${name}`;
+      instance.register(longName, classFromObject(obj));
+      return instance.lookup(longName);
+    }
+
+    test('the case when route._prefetched is undefined is accounted for', function(assert) {
+      assert.expect(1);
+
+      const _super = this.spy();
+      const route = classFromSpy(_super).create();
+      try {
+        route.model();
+      } catch(e) {
+        assert.ok(false, 'the model hook doesn\'t die with route._prefetched is undefined');
+      }
+
+      assert.ok(_super.calledOnce, 'the super class\'s model hook is called');
+    });
+
+    test('the prefetched method returns the promise for the specified route', function(assert) {
+      assert.expect(2);
+
+      const parentData = {};
+      registerRoute('parent', { _prefetched: parentData });
+
+      const selfData = {};
+      const selfRoute = registerRoute('self', { _prefetched: selfData });
+
+      assert.equal(selfRoute.prefetched('parent')._result, parentData, 'prefetched returns the promise of the named route');
+      assert.equal(selfRoute.prefetched()._result, selfData, 'prefetched returns the promise of the calling route when no name is given');
+    });
+
+    function modelHookTestingHelper(hook) {
+      const router = instance.lookup('router:main');
+
+      // simulate prefetch being defined
+      const obj = {};
+      const spy = this.stub().returns(obj);
+      const Route = classFromSpy(spy);
+      const route = typeof hook === 'function' ? Route.create({ prefetch: hook }) : Route.create();
+      const handlerInfoWithPrefetch = {
+        runSharedModelHook(_, hookName) {
+          if (hookName === 'prefetch') {
+            return Promise.resolve(this.handler.prefetch());
+          }
+        },
+        handler: route,
+      };
+      const transitionWithPrefetch = { handlerInfos: [handlerInfoWithPrefetch] };
+
+      router.trigger('willTransition', transitionWithPrefetch);
+
+      return {
+        route,
+        spy,
+        model: obj,
+      };
+    }
+
+    test('the model hook returns the result of prefetch if a prefetch hook is defined', function(assert) {
+      assert.expect(3);
+
+      const data = {};
+      function prefetch() {
+        return data;
+      }
+      const { model, route, spy: _super } = modelHookTestingHelper.call(this, prefetch);
+
+      return route.model().then((result) => {
+        assert.equal(result, data, 'the model hook returns a promise that resolves with the result of the prefetch hook');
+        assert.notEqual(result, model, 'the promise is not resolved the with result of the super class\'s model hook');
+        assert.notOk(_super.called, 'the super class\'s model hook is not called');
+      });
+    });
+
+    test('the model hook calls super if no prefetch hook is defined', function(assert) {
+      assert.expect(2);
+
+      const { model, route, spy: _super } = modelHookTestingHelper.call(this);
+
+      return route.model().then((result) => {
+        assert.equal(result, model, 'the model hook returns a promise that resolves with the result of the super class\'s model hook');
+        assert.ok(_super.called, 'the super class\'s model hook is called');
+      });
     });
   });
-
-  test('the model hook calls super if no prefetch hook is defined', function(assert) {
-    assert.expect(2);
-
-    const { model, route, spy: _super } = modelHookTestingHelper.call(this);
-
-    return route.model().then((result) => {
-      assert.equal(result, model, 'the model hook returns a promise that resolves with the result of the super class\'s model hook');
-      assert.ok(_super.called, 'the super class\'s model hook is called');
-    });
-  });
-});
+}

--- a/tests/unit/util/diff-route-infos-test.js
+++ b/tests/unit/util/diff-route-infos-test.js
@@ -1,0 +1,219 @@
+import { paramsDiffer, pathsDiffer, qpsChanged, shouldRefreshModel } from 'ember-prefetch/-private/diff-route-info';
+import { module, test } from 'qunit';
+import { assign } from '@ember/polyfills';
+import { gte } from 'ember-compatibility-helpers';
+
+if (gte('3.6.0')) {
+  module('paramsDiffer', () => {
+    test('returns false if the params match', (assert) => {
+      let info = {
+        paramNames: ['post_id', 'comment_id'],
+        params: { post_id: '1', comment_id: '1' }
+      };
+      assert.notOk(paramsDiffer([info], [info]))
+    });
+
+    test('returns true if the params mismatch', (assert) => {
+      let info = {
+        paramNames: ['post_id', 'comment_id'],
+        params: { post_id: '1', comment_id: '1' }
+      };
+      let info2 = assign({}, info, { params: { post_id: '2' } });
+      assert.ok(paramsDiffer([info], [info2]))
+    });
+
+    test('returns true if the paramNames mismatch', (assert) => {
+      let info = {
+        paramNames: ['post_id', 'comment_id'],
+        params: { post_id: '1', comment_id: '1' }
+      };
+      let info2 = assign({}, info, { paramNames: ['picture_id', 'comment_id'] });
+      assert.ok(paramsDiffer([info], [info2]))
+    });
+
+    test('returns true if paramNames are empty', (assert) => {
+      let info = {
+        paramNames: ['post_id', 'comment_id'],
+        params: { post_id: '1', comment_id: '1' }
+      };
+      let info2 = assign({}, info, { paramNames: [] });
+      assert.ok(paramsDiffer([info], [info2]))
+    });
+
+    test('returns true if params are empty', (assert) => {
+      let info = {
+        paramNames: ['post_id', 'comment_id'],
+        params: { post_id: '1', comment_id: '1' }
+      };
+      let info2 = assign({}, info, { params: {} });
+      assert.ok(paramsDiffer([info], [info2]))
+    });
+
+    test('smoke test (different)', (assert) => {
+      let infos1 = [];
+      let infos2 = [];
+
+      for (let i = 0; i < 10; i++) {
+        infos1.push({
+          paramNames: [`${i}`],
+          params: [{ [`${i}`]: 'foo' }]
+        });
+
+        infos2.push({
+          paramNames: [`${i}*`],
+          params: [{ [`${i}*`]: 'bar' }]
+        });
+      }
+
+      assert.ok(paramsDiffer(infos1, infos2));
+    });
+
+    test('smoke test (same)', (assert) => {
+      let infos1 = [];
+      let infos2 = [];
+
+      for (let i = 0; i < 10; i++) {
+        let info = {
+          paramNames: [`${i}`],
+          params: [{ [`${i}`]: 'foo' }]
+        };
+        infos1.push(info);
+        infos2.push(info);
+      }
+
+      assert.notOk(paramsDiffer(infos1, infos2));
+    });
+  });
+
+  module('pathsDiffer', () => {
+    test('returns false if the paths are the same', (assert) => {
+      let info = {
+        name: 'foo.bar'
+      };
+      assert.notOk(pathsDiffer([info], [info]))
+    });
+
+    test('returns true if the paths changed', (assert) => {
+      let info = {
+        name: 'foo.bar'
+      };
+      let info2 = assign({}, info, { name: 'baz.bar' });
+      assert.ok(pathsDiffer([info], [info2]))
+    });
+
+    test('returns true if the paths changed', (assert) => {
+      let info = {
+        name: 'foo.bar'
+      };
+      let info2 = assign({}, info, { name: 'baz.bar' });
+      assert.ok(pathsDiffer([info], [info2]))
+    });
+
+    test('returns true if the paths mismatch', (assert) => {
+      let infos1 = [];
+      let infos2 = [];
+
+      for (let i = 0; i < 10; i++) {
+        infos1.push({
+          name: `${i}`
+        });
+
+        infos2.push({
+          name: i % 2 ? `${i}` : `index`
+        });
+      }
+      assert.ok(pathsDiffer(infos1, infos2))
+    });
+  });
+
+  module('qpsChanged', () => {
+    test('returns false if query params have not changed', (assert) => {
+      let info = {
+        queryParams: { a: 'b', c: 'd' }
+      };
+      assert.notOk(qpsChanged(info, info))
+    });
+
+    test('returns true if the query params have been removed', (assert) => {
+      let info = {
+        queryParams: { a: 'b', c: 'd' }
+      };
+      let info2 = {
+        queryParams: { a: 'b' }
+      };
+      assert.ok(qpsChanged(info, info2))
+    });
+
+    test('returns true if the query params have changed', (assert) => {
+      let info = {
+        queryParams: { a: 'b', c: 'd' }
+      };
+      let info2 = {
+        queryParams: { a: 'b', c: 'true' }
+      };
+      assert.ok(qpsChanged(info, info2))
+    });
+
+    test('returns true query params have been added', (assert) => {
+      let info = {
+        queryParams: { a: 'b', c: 'd' }
+      };
+      let info2 = {
+        queryParams: { a: 'b', c: 'd', e: 'f' }
+      };
+      assert.ok(qpsChanged(info, info2))
+    });
+
+    test('returns true query params have been completely removed', (assert) => {
+      let info = {
+        queryParams: { a: 'b', c: 'd' }
+      };
+      let info2 = {
+        queryParams: {}
+      };
+      assert.ok(qpsChanged(info, info2))
+    });
+  });
+
+  module('shouldRefreshModel', () => {
+    test('returns true if the `refreshModel` is set to true for a given QP', (assert) => {
+      let routeQp = {
+        foo: { refreshModel: true }
+      };
+      let queryParams = {
+        foo: 'bar'
+      }
+      assert.ok(shouldRefreshModel(routeQp, queryParams))
+    });
+
+    test('returns false if refreshModel isnt set', (assert) => {
+      let routeQp = {};
+      let queryParams = {
+        foo: 'bar'
+      }
+      assert.notOk(shouldRefreshModel(routeQp, queryParams))
+    });
+
+    test('returns false if refreshModel isnt set for a given qp', (assert) => {
+      let routeQp = {
+        bar: { refreshModel: true }
+      };
+      let queryParams = {
+        foo: 'bar'
+      }
+      assert.notOk(shouldRefreshModel(routeQp, queryParams))
+    });
+
+    test('returns true if refreshModel is set for any qp', (assert) => {
+      let routeQp = {
+        bar: { refreshModel: true }
+      };
+      let queryParams = {
+        foo: 'bar',
+        biz: 'baz',
+        bar: 'woot'
+      }
+      assert.ok(shouldRefreshModel(routeQp, queryParams))
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,6 +1169,13 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0-beta.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0-beta.6.tgz#ecdf6e408d5c863ab21740d7ad7f43f027d2f912"
@@ -3096,7 +3103,7 @@ ember-cli-uglify@^2.1.0:
     broccoli-uglify-sourcemap "^2.1.1"
     lodash.defaultsdeep "^4.6.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
@@ -3200,6 +3207,15 @@ ember-cli@~3.7.1:
     watch-detector "^0.1.0"
     yam "^1.0.0"
 
+ember-compatibility-helpers@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
+  integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
@@ -3293,9 +3309,9 @@ ember-source-channel-url@^1.0.1, ember-source-channel-url@^1.1.0:
     got "^8.0.1"
 
 ember-source@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.7.0.tgz#99d8d306daf05a7a8063adcb944b04a9c9c94be7"
-  integrity sha512-4Ne361XAwLV0hYfFSbZP8NJUzD1IZLWHO1ON9Hb67K9B67H+3CF6SdbE+3+V+WiIom1n93/M35A72sNmh9CTjg==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.7.2.tgz#2167b667db1dc4b78cea881a5c739ce851109073"
+  integrity sha512-QJcTmxVeVsL+sdllwZOazelG1V+jq7l9YmDAdDZ0lqf/JtGdQbdCScoYq9+9V52wajoD7qD1GD0Uxrl+PTk/5Q==
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^3.0.2"


### PR DESCRIPTION
In Ember 3.6 we introduced a public way of getting meta data about a
route via a `RoutInfo`. A `RouteInfo` is a public version of handlerInfo.
We also introduced new router events that see things such as aborts, retries,
redirects etc. With these 2 changes we are able to remove the vast majority of
the private API usage in this addon. The only place we do need the private api
usage is looking up the actual route instance. We cannot use `getOwner` because
the owner is not going to have visibility into engines. Also, it appears we need
to schedule the `prefetch` calls into the `actions` queue to get the same timing
semantics that we had before, which was chaining off of some internal promise in
the router.