### PR TITLE
[BUGFIX] Fix QueryParam diffing

### DIFF
--- a/tests/acceptance/query-params-test.js
+++ b/tests/acceptance/query-params-test.js
@@ -146,6 +146,22 @@ module('Acceptance | query-params', function(hooks) {
     assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was not run again');
   });
 
+  test('changing a query param does not run the prefetch hook (when other queryParams are set)', async function (assert) {
+    assert.expect(4);
+
+    await visit(`${QUERYPARAMS_ROUTE_URL}`);
+
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run for the initial transition');
+
+    await this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: 'biz' } });
+    await this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: 'biz', foo: 'bar' } });
+
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.substring(url.indexOf('?')), '?fiz=biz&foo=bar', 'the query params are set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'the prefetch hook was only run twice');
+  });
+
   test('changing a query param marked with refreshModel runs the prefetch hook', async function(assert) {
     assert.expect(4);
 
@@ -180,5 +196,21 @@ module('Acceptance | query-params', function(hooks) {
     assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
     assert.equal(url.substring(url.indexOf('?')), '?fib=fab&fiz=baz', 'the query params are set');
     assert.equal(window.QueryparamsRoute_prefetch_hasRun, 2, 'the prefetch hook was run again');
+  });
+
+  test('removing a query param marked with refreshModel runs the prefetch hook', async function (assert) {
+    assert.expect(4);
+
+    await visit(`${QUERYPARAMS_ROUTE_URL}`);
+
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 1, 'the prefetch hook was run for the initial transition');
+
+    await this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: 'baz', foo: null } });
+    await this.router.transitionTo(QUERYPARAMS_ROUTE_NAME, { queryParams: { fiz: null, foo: null } });
+
+    const url = currentURL();
+    assert.equal(currentRouteName(), QUERYPARAMS_ROUTE_NAME, 'the desired route is reached');
+    assert.equal(url.indexOf('?'), -1, 'the query param is set');
+    assert.equal(window.QueryparamsRoute_prefetch_hasRun, 3, 'the prefetch hook was run again');
   });
 });


### PR DESCRIPTION
The current logic for query param diffing has a couple issues:

1. It only triggers based on the QPs in the `to` URL. Since any QPs
   which have been _removed_ by the transition will not be in the `to`
   state, and will only be in the `from` state, this will not trigger
   the model's prefetch hook, even though the `model` hook is run.
2. It triggers currently if _any_ QP exists in the `to` transition that
   is marked as `refreshModel`. For instance, let's say we have this QP
   setup:

   ```js
   queryParams: {
     category: { refreshModel: true },
     otherCategory: { refreshModel: false },
   },
   ```

   If `category` has a value (e.g. `category=food`), and we remove
   `otherCategory`, we currently will still trigger the prefetch even
   though the only QP that changed was `otherCategory`.

This PR fixes these issues by creating a single diff of the QPs and
using that for all of the checks.