### PR TITLE
Fix sibling transitions and text qp transitions 

### DIFF
--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -123,15 +123,13 @@ if (gte('3.6.0')) {
     let toList = createList(transition.to);
     let fromList = createList(transition.from);
 
-    // Paths Changed
-    if (toList.length !== fromList.length) {
+    if (fromList.length === 0) {
       return { shouldCall: true, for: getPrefetched(privateRouter, toList) };
     }
 
     let pathResult = pathsDiffer(fromList, toList);
 
     let [_pathsDiffer] = pathResult;
-
 
     if (_pathsDiffer) {
       let [, pivot] = pathResult;

--- a/tests/acceptance/hook-calls-test.js
+++ b/tests/acceptance/hook-calls-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import Route from '@ember/routing/route';
+import Controller from '@ember/controller';
+import { gte } from 'ember-compatibility-helpers';
 
 module('Route hooks', function(hooks) {
   setupApplicationTest(hooks);
@@ -24,9 +26,54 @@ module('Route hooks', function(hooks) {
         assert.step('parent');
       }
     }));
+
     this.owner.register('route:parent.child', Route.extend({
       prefetch() {
         assert.step('child');
+      }
+    }));
+
+    this.owner.register('route:queryparams-children', Route.extend({
+      queryParams: {
+        fib: {
+          refreshModel: true,
+        },
+        fiz: {
+          refreshModel: true,
+        },
+      },
+      prefetch() {
+        assert.step('queryparams-children');
+      }
+    }));
+
+    this.owner.register('route:queryparams-children.index', Route.extend({
+      prefetch() {
+        assert.step('queryparams-children.index');
+      }
+    }));
+
+    this.owner.register('controller:queryparams-children', Controller.extend({
+      queryParams: [
+        'fib',
+        'fiz',
+      ],
+    }));
+
+    this.owner.register('controller:queryparams-children.child', Controller.extend({
+      queryParams: [
+        'bar',
+      ],
+    }));
+
+    this.owner.register('route:queryparams-children.child', Route.extend({
+      queryParams: {
+        bar: {
+          refreshModel: true,
+        }
+      },
+      prefetch() {
+        assert.step('queryparams-children.child');
       }
     }));
 
@@ -71,6 +118,87 @@ module('Route hooks', function(hooks) {
       'parent',
       'child',
       'sibling'
+    ]);
+  });
+
+  test('hook counts for refresh qps', async function(assert) {
+    await visit('/parent/child');
+
+    await this.owner.lookup('service:router').transitionTo('/qp');
+
+
+    await this.owner.lookup('service:router').transitionTo('queryparams-children', { queryParams: { fiz: true } });
+
+    assert.equal(currentURL(), '/qp?fiz=true');
+
+    try {
+      await this.owner.lookup('service:router').transitionTo('queryparams-children.child', { queryParams: { bar: true } });
+    } catch (e) {
+      assert.equal(e.name, 'TransitionAborted')
+    }
+
+    await this.owner.lookup('service:router').transitionTo('/parent/child');
+
+    if (gte('3.6.0')) {
+      assert.verifySteps([
+        'application',
+        'parent',
+        'child',
+        'queryparams-children',
+        'queryparams-children.index',
+        'queryparams-children',
+        'queryparams-children.child',
+        'parent',
+        'child'
+      ]);
+    } else {
+      assert.verifySteps([
+        'application',
+        'parent',
+        'child',
+        'queryparams-children',
+        'queryparams-children.index',
+        'queryparams-children',
+        'queryparams-children.index',
+        'queryparams-children.child',
+        'parent',
+        'child'
+      ]);
+    }
+  });
+
+  test('hook counts for non-refreshable qps', async function(assert) {
+    this.owner.register('route:queryparams-children', Route.extend({
+      prefetch() {
+        assert.step('queryparams-children');
+      }
+    }));
+    await visit('/parent/child');
+
+    await this.owner.lookup('service:router').transitionTo('/qp');
+
+
+    await this.owner.lookup('service:router').transitionTo('queryparams-children', { queryParams: { fiz: true } });
+
+    assert.equal(currentURL(), '/qp?fiz=true');
+
+    try {
+      await this.owner.lookup('service:router').transitionTo('queryparams-children.child', { queryParams: { bar: true } });
+    } catch (e) {
+      assert.equal(e.name, 'TransitionAborted')
+    }
+
+    await this.owner.lookup('service:router').transitionTo('/parent/child');
+
+    assert.verifySteps([
+      'application',
+      'parent',
+      'child',
+      'queryparams-children',
+      'queryparams-children.index',
+      'queryparams-children.child',
+      'parent',
+      'child'
     ]);
   });
 });

--- a/tests/acceptance/hook-calls-test.js
+++ b/tests/acceptance/hook-calls-test.js
@@ -7,6 +7,18 @@ module('Route hooks', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function(assert) {
+    this.owner.register('route:application', Route.extend({
+      prefetch() {
+        assert.step('application');
+      }
+    }));
+
+    this.owner.register('route:foo', Route.extend({
+      prefetch() {
+        assert.step('foo');
+      }
+    }));
+
     this.owner.register('route:parent', Route.extend({
       prefetch() {
         assert.step('parent');
@@ -32,6 +44,30 @@ module('Route hooks', function(hooks) {
     await this.owner.lookup('service:router').transitionTo('/parent/sibling');
 
     assert.verifySteps([
+      'application',
+      'parent',
+      'child',
+      'sibling'
+    ]);
+  });
+
+  test('hook counts for child routes', async function(assert) {
+    await visit('/parent/child');
+
+    await this.owner.lookup('service:router').transitionTo('/parent/sibling');
+
+    await this.owner.lookup('service:router').transitionTo('/foo');
+
+    await this.owner.lookup('service:router').transitionTo('/parent/child');
+
+    await this.owner.lookup('service:router').transitionTo('/parent/sibling');
+
+    assert.verifySteps([
+      'application',
+      'parent',
+      'child',
+      'sibling',
+      'foo',
       'parent',
       'child',
       'sibling'

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,9 @@ Router.map(function() {
   this.route('bar');
   this.route('queryparams');
   this.route('queryparams-helper');
+  this.route('queryparams-children', { path: '/qp' }, function() {
+    this.route('child');
+  });
 
   this.route('parent', function() {
     this.route('child');


### PR DESCRIPTION
Note: It appears there is a bug in ember-prefetch + ember <= 3.5 where exiting routes with refreshable qps get their `prefetch` hook called again.
