### PR TITLE
Drop support for Node 6 and 11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -13,8 +13,6 @@ addons:
 
 cache:
   yarn: true
-  directories:
-    - $HOME/.npm
 
 env:
   global:
@@ -38,9 +36,9 @@ jobs:
     - stage: "Tests"
       name: "Tests"
       script:
-        - npm run lint:hbs
-        - npm run lint:js
-        - npm test
+        - yarn lint:hbs
+        - yarn lint:js
+        - yarn test
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
@@ -52,10 +50,8 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
-before_install:
-  - npm config set spin false
-  - npm install -g npm@4
-  - npm --version
+install:
+  - yarn install --no-lockfile --non-interactive
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,6 +9,7 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then((urls) => {
     return {
+      useYarn: true,
       scenarios: [
         {
           name: 'ember-lts-2.18',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:all": "ember try:each"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",


### PR DESCRIPTION
In preparation for adding ember-engines for testing lazy
routes, this sets node version for CI to 8 and updates
node engines to reflect that 8 is the lowest supported
version. Also updates to use yarn for installing depdencies.
The flags are added to prevent install failures related to
having "link" dependencies in package.json. I referred to
ember-engines repo for these changes.

https://github.com/ember-engines/ember-engines/blob/v0.8.2/package.json#L43
https://github.com/ember-engines/ember-engines/blob/v0.8.2/.travis.yml#L54

Related PR: https://github.com/nickiaconis/ember-prefetch/pull/150