### PR TITLE
Handle route refresh and invoke prefetch for manual route.refresh()

### DIFF
--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -1,11 +1,13 @@
 import { assign } from '@ember/polyfills';
 import { gte } from 'ember-compatibility-helpers';
+import { assert } from '@ember/debug';
 
 export let diffQPs;
 export let shouldRefreshModel;
 export let pathsDiffer;
 export let paramsDiffer;
 export let createPrefetchChangeSet;
+export let pathsRefresh;
 
 if (gte('3.6.0')) {
   // remove guard for Ember 3.8 LTS and rev major
@@ -128,6 +130,46 @@ if (gte('3.6.0')) {
     return routes;
   }
 
+  // This should be invoked if there are no results for queryparams diff(qpsDiff) due to overlapping logic
+  pathsRefresh = function(from, to, intent) {
+    let pivotIndex = -1;
+    let hasMatch = false;
+
+    if (!from || !intent || from.length !== to.length || !intent.pivotHandler) {
+      return [hasMatch, pivotIndex];
+    }
+
+    // only route.refresh and route.refreshModel hook have `NamedTransitionIntent` and has routeName
+    const refreshRouteName = intent.pivotHandler.routeName;
+
+    for (let i = 0; i < from.length; i++) {
+      if (from[i].name === refreshRouteName) {
+        return [true, i];
+      }
+    }
+    assert(
+      'This return section should not be reachable. `refreshRouteName` should be always present for `route.refresh()`'
+    );
+    return [hasMatch, pivotIndex];
+  };
+
+  /**
+    This function checks transition in sequence 
+    1. param has changed
+    2. route has changed
+    3. query param has changed
+    4. refresh has invoked from route
+    
+    This checking sequence is important, changing sequence could impact in weird ways. 
+    For examample, query param invokes route.refresh() if refreshModel is set true on route level.
+    If #4 has invoked prior to #3, it will visit index route of refreshModel hence involves in additional API invocation
+
+    @method createPrefetchChangeSet
+    @param {Object} privateRouter - router
+    @param {Object} transition - transition object
+    @return {Object} An object containing `shouldCall` to invoke prefetch promise on each route and `for` to iterate through affected routes
+    @public
+  */
   createPrefetchChangeSet = function(privateRouter, transition) {
     let toList = createList(transition.to);
     let fromList = createList(transition.from);
@@ -146,6 +188,7 @@ if (gte('3.6.0')) {
       return { shouldCall: true, for: getPrefetched(privateRouter, pivotHandlers) };
     }
 
+    // Path has changed
     let pathResult = pathsDiffer(fromList, toList);
 
     let [_pathsDiffer] = pathResult;
@@ -157,6 +200,21 @@ if (gte('3.6.0')) {
     }
 
     // Query Params changed
-    return qpsDiffer(privateRouter, toList, transition);
+    let qpsResult = qpsDiffer(privateRouter, toList, transition);
+    if (qpsResult.shouldCall) {
+      return qpsResult;
+    }
+
+    // route.refresh has invoked
+    let refreshResult = pathsRefresh(fromList, toList, transition.intent);
+    let [_isRefresh] = refreshResult;
+
+    if (_isRefresh) {
+      let [, pivot] = refreshResult;
+      let pivotHandlers = toList.splice(pivot);
+      return { shouldCall: true, for: getPrefetched(privateRouter, pivotHandlers) };
+    }
+
+    return { shouldCall: false };
   };
 }

--- a/tests/acceptance/model-refresh-test.js
+++ b/tests/acceptance/model-refresh-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, click } from '@ember/test-helpers';
+
+module('Acceptance | refresh', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test("Child route.refresh should reflect parent model's refreshed values", async function(assert) {
+    assert.expect(4);
+
+    await visit('/refresh-parent');
+
+    await click('.link-to-child');
+
+    assert.equal(
+      document.getElementById('parent-value').textContent,
+      'original',
+      'parent value should be original'
+    );
+    assert.equal(
+      document.getElementById('child-value').textContent,
+      'original',
+      'child value should be original'
+    );
+
+    await click('#modify-button');
+    assert.equal(
+      document.getElementById('parent-value').textContent,
+      'modified',
+      'parent value should be modified'
+    );
+    assert.equal(
+      document.getElementById('child-value').textContent,
+      'modified',
+      'child value should be modified'
+    );
+  });
+
+  test('route.refresh should invoke prefetched to reflect current value', async function(assert) {
+    assert.expect(3);
+
+    await visit('/refresh-parent');
+
+    await click('.link-to-child');
+
+    assert.equal(
+      document.getElementById('counter-value').textContent,
+      '0',
+      'Current counter should be 0'
+    );
+
+    await click('#refresh-current-button');
+    assert.equal(
+      document.getElementById('counter-value').textContent,
+      '1',
+      'Current counter should be 1'
+    );
+
+    await click('#refresh-current-button');
+    assert.equal(
+      document.getElementById('counter-value').textContent,
+      '2',
+      'Current counter should be 2'
+    );
+  });
+});

--- a/tests/dummy/app/controllers/refresh-parent/refresh-child.js
+++ b/tests/dummy/app/controllers/refresh-parent/refresh-child.js
@@ -1,0 +1,13 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    modifyValue() {
+      this.send('updateParentValue');
+      this.send('refreshChild');
+    },
+    refreshCurrent() {
+      this.send('refreshChild');
+    },
+  },
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -28,6 +28,10 @@ Router.map(function() {
     this.route('sibling');
   });
 
+  this.route('refresh-parent', function() {
+    this.route('refresh-child');
+  });
+
   this.route('abort-transition-to-child', function() {
     this.route('child');
   });

--- a/tests/dummy/app/routes/refresh-parent.js
+++ b/tests/dummy/app/routes/refresh-parent.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  serveOriginalValue: true,
+  prefetch() {
+    return {
+      originalValue: this.serveOriginalValue ? 'original' : 'modified',
+    };
+  },
+
+  actions: {
+    updateParentValue() {
+      this.serveOriginalValue = false;
+      this.refresh();
+    },
+  },
+});

--- a/tests/dummy/app/routes/refresh-parent/refresh-child.js
+++ b/tests/dummy/app/routes/refresh-parent/refresh-child.js
@@ -1,0 +1,20 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  counter: 0,
+  prefetch() {
+    const parentModel = this.prefetched('refreshParent');
+    return parentModel.then(model => {
+      return {
+        derivedParentValue: model.originalValue,
+        currentCounter: this.counter++,
+      };
+    });
+  },
+
+  actions: {
+    refreshChild() {
+      this.refresh();
+    },
+  },
+});

--- a/tests/dummy/app/templates/refresh-parent.hbs
+++ b/tests/dummy/app/templates/refresh-parent.hbs
@@ -1,0 +1,6 @@
+<h2>Parent</h2>
+<p> Parent Value: <span id="parent-value">{{model.originalValue}}</span> </p>
+{{outlet}}
+{{#link-to "refresh-parent.refresh-child" classNames="link-to-child"}}
+  To Child
+{{/link-to}}

--- a/tests/dummy/app/templates/refresh-parent/refresh-child.hbs
+++ b/tests/dummy/app/templates/refresh-parent/refresh-child.hbs
@@ -1,0 +1,5 @@
+<h3>Child</h3>
+<p> derivedParentValue: <span id="child-value">{{model.derivedParentValue}}</span></p>
+<p> currentCounter: <span id="counter-value">{{model.currentCounter}}</span></p>
+<button id="modify-button" {{action "modifyValue"}}>Modify All Values</button>
+<button id="refresh-current-button" {{action "refreshCurrent"}}>Refresh only child</button>

--- a/tests/unit/util/diff-route-infos-test.js
+++ b/tests/unit/util/diff-route-infos-test.js
@@ -3,6 +3,7 @@ import {
   pathsDiffer,
   diffQPs,
   shouldRefreshModel,
+  pathsRefresh,
 } from 'ember-prefetch/-private/diff-route-info';
 import { module, test } from 'qunit';
 import { assign } from '@ember/polyfills';
@@ -187,6 +188,72 @@ if (gte('3.6.0')) {
         queryParams: {},
       };
       assert.deepEqual(diffQPs(info, info2), ['a', 'c']);
+    });
+  });
+
+  module('pathRefresh', () => {
+    test('returns false if the paths are the same but do not have any intent', assert => {
+      let info = {
+        name: 'foo.bar',
+      };
+      let [match] = pathsRefresh([info], [info], undefined);
+      assert.notOk(match);
+    });
+
+    test('returns false if the paths are different', assert => {
+      let info = [{ name: 'foo.bar' }];
+
+      let intent = {
+        pivotHandler: {
+          routeName: 'foo',
+        },
+      };
+
+      let info2 = [info[0], { name: 'baz.bar' }];
+      let [match] = pathsRefresh(info, info2, intent);
+      assert.notOk(match);
+    });
+
+    test('returns true if the paths match and has pivotRouteName same as parent route', assert => {
+      let info = [
+        {
+          name: 'foo',
+        },
+        {
+          name: 'foo.bar',
+        },
+      ];
+
+      let intent = {
+        pivotHandler: {
+          routeName: 'foo',
+        },
+      };
+
+      let info2 = info;
+      let [match] = pathsRefresh(info, info2, intent);
+      assert.ok(match);
+    });
+
+    test('returns true if the paths match and has pivotRouteName same as leaf route', assert => {
+      let info = [
+        {
+          name: 'foo',
+        },
+        {
+          name: 'foo.bar',
+        },
+      ];
+
+      let intent = {
+        pivotHandler: {
+          routeName: 'foo.bar',
+        },
+      };
+
+      let info2 = info;
+      let [match] = pathsRefresh(info, info2, intent);
+      assert.ok(match);
     });
   });
 


### PR DESCRIPTION
When route invokes `refresh()` method, `diff-route-info` ended up delegating it's logic to `qpsDiff`(query params diff) method. This RB introduces handling `route.refresh` by checking `transition.intent`, `transition.from` and `transition.to` to see if `refresh()` has invoked by user action by introducing a new method `pathsRefresh`.