### PR TITLE
Ensure `prefetch` hook will be called on routes within a lazy engine

### DIFF
--- a/addon/initializers/prefetch.js
+++ b/addon/initializers/prefetch.js
@@ -1,13 +1,12 @@
 import Route from '@ember/routing/route';
 import RouteMixin from 'ember-prefetch/mixins/route';
+import { gte } from 'ember-compatibility-helpers';
 
-let hasInitialized = false;
+Route.reopen(RouteMixin);
 
-export function initialize() {
-  if (!hasInitialized) {
-    hasInitialized = true;
-
-    Route.reopen(RouteMixin);
+export function initialize(application) {
+  if (gte('3.6.0')) {
+    application.inject('route:application', '__prefetch', 'service:prefetch');
   }
 }
 

--- a/addon/instance-initializers/prefetch.js
+++ b/addon/instance-initializers/prefetch.js
@@ -3,9 +3,7 @@ import { resolve } from 'rsvp';
 import { gte } from 'ember-compatibility-helpers';
 
 export function initialize(instance) {
-  if (gte('3.6.0')) {
-    instance.inject('route:application', '__prefetch', 'service:prefetch');
-  } else {
+  if (!gte('3.6.0')) {
     // Delete all of this in the Ember 3.8 LTS and rev major
     const ROUTER_NAME = 'router:main';
     const router = instance.lookup(ROUTER_NAME);

--- a/addon/services/prefetch.js
+++ b/addon/services/prefetch.js
@@ -1,7 +1,6 @@
 import Service, { inject as service } from '@ember/service';
-import { schedule } from '@ember/runloop';
 import { createPrefetchChangeSet } from '../-private/diff-route-info';
-import RSVP from 'rsvp';
+import { Promise, all } from 'rsvp';
 import { gte } from 'ember-compatibility-helpers';
 
 let PrefetchService;
@@ -13,7 +12,6 @@ if (gte('3.6.0')) {
     router: service('router'),
     init() {
       this._super(...arguments);
-      let privateRouter = this.router._router._routerMicrolib;
       let seenRoutes = new WeakMap();
 
       this.router.on('routeWillChange', transition => {
@@ -21,15 +19,17 @@ if (gte('3.6.0')) {
           return;
         }
 
-        schedule('actions', () => {
+        let routePromises = transition.routeInfos.map(info => info._routePromise);
+        all(routePromises).then(() => {
           if (!this.isDestroying && !this.isDestroyed) {
+            let privateRouter = this.router._router._routerMicrolib;
             let changeSet = createPrefetchChangeSet(privateRouter, transition);
             if (changeSet.shouldCall) {
               for (let i = 0; i < changeSet.for.length; i++) {
                 let { route, fullParams } = changeSet.for[i];
                 if (seenRoutes.has(route)) continue;
 
-                route._prefetched = new RSVP.Promise(r => {
+                route._prefetched = new Promise(r => {
                   return r(route.prefetch(fullParams, transition));
                 });
                 seenRoutes.set(route, true);

--- a/addon/services/prefetch.js
+++ b/addon/services/prefetch.js
@@ -7,6 +7,7 @@ import { gte } from 'ember-compatibility-helpers';
 let PrefetchService;
 
 if (gte('3.6.0')) {
+  let substatesRegex = /(^|_|\.)(loading$|error$)/;
   // remove guard for Ember 3.8 LTS and rev major
   PrefetchService = Service.extend({
     router: service('router'),
@@ -16,7 +17,7 @@ if (gte('3.6.0')) {
       let seenRoutes = new WeakMap();
 
       this.router.on('routeWillChange', transition => {
-        if (transition.to && /(^|_|\.)(loading$|error$)/.test(transition.to.name)) {
+        if (transition.to && substatesRegex.test(transition.to.name)) {
           return;
         }
 

--- a/testem.js
+++ b/testem.js
@@ -9,7 +9,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/tests/acceptance/engine-test.js
+++ b/tests/acceptance/engine-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import Route from '@ember/routing/route';
+import Engine from '@ember/engine';
+import Controller from '@ember/controller';
+import hbs from 'htmlbars-inline-precompile';
+import AppRouter from 'dummy/router';
+import setupRouterForEngine from '../helpers/setup-router-for-engine';
+
+module('lazy engine loading', function(hooks) {
+  setupApplicationTest(hooks);
+  setupRouterForEngine(hooks);
+
+  hooks.beforeEach(function(assert) {
+    this.owner.register(
+      'route:application',
+      Route.extend({
+        prefetch() {
+          assert.step('application');
+        },
+      })
+    );
+    this.owner.register('template:application', hbs`{{outlet}}`);
+    this.owner.register('controller:application', Controller.extend());
+    debugger;
+    AppRouter.map(function() {
+      this.mount('blog');
+    });
+    this.owner.register('route-map:blog', function() {
+      this.route('post');
+    });
+    this.owner.register('engine:blog', Engine.extend({
+      init() {
+        this._super(...arguments);
+        this.register('template:application', hbs`{{outlet}}`);
+        this.register('controller:application', Controller.extend());
+
+        this.register('template:post', hbs`Post {{this.model}}`);
+        this.register('route:application', Route.extend({
+          prefetch() {
+            assert.step('blog-application');
+          }
+        }));
+        this.register('route:post', Route.extend({
+          prefetch() {
+            assert.step('blog-post');
+          }
+        }));
+      }
+    }))
+  });
+
+  test('prefetch hook on lazy engine is called', async function(assert) {
+    await visit('/blog/post');
+    assert.verifySteps(['application', 'blog-application', 'blog-post']);
+    assert.equal(currentURL(), '/blog/post');
+  });
+});
+

--- a/tests/acceptance/engine-test.js
+++ b/tests/acceptance/engine-test.js
@@ -23,32 +23,40 @@ module('lazy engine loading', function(hooks) {
     );
     this.owner.register('template:application', hbs`{{outlet}}`);
     this.owner.register('controller:application', Controller.extend());
-    debugger;
     AppRouter.map(function() {
       this.mount('blog');
     });
     this.owner.register('route-map:blog', function() {
       this.route('post');
     });
-    this.owner.register('engine:blog', Engine.extend({
-      init() {
-        this._super(...arguments);
-        this.register('template:application', hbs`{{outlet}}`);
-        this.register('controller:application', Controller.extend());
+    this.owner.register(
+      'engine:blog',
+      Engine.extend({
+        init() {
+          this._super(...arguments);
+          this.register('template:application', hbs`{{outlet}}`);
+          this.register('controller:application', Controller.extend());
 
-        this.register('template:post', hbs`Post {{this.model}}`);
-        this.register('route:application', Route.extend({
-          prefetch() {
-            assert.step('blog-application');
-          }
-        }));
-        this.register('route:post', Route.extend({
-          prefetch() {
-            assert.step('blog-post');
-          }
-        }));
-      }
-    }))
+          this.register('template:post', hbs`Post {{this.model}}`);
+          this.register(
+            'route:application',
+            Route.extend({
+              prefetch() {
+                assert.step('blog-application');
+              },
+            })
+          );
+          this.register(
+            'route:post',
+            Route.extend({
+              prefetch() {
+                assert.step('blog-post');
+              },
+            })
+          );
+        },
+      })
+    );
   });
 
   test('prefetch hook on lazy engine is called', async function(assert) {
@@ -57,4 +65,3 @@ module('lazy engine loading', function(hooks) {
     assert.equal(currentURL(), '/blog/post');
   });
 });
-

--- a/tests/helpers/setup-router-for-engine.js
+++ b/tests/helpers/setup-router-for-engine.js
@@ -1,0 +1,61 @@
+import RSVP from 'rsvp';
+
+/**
+ * Modifies the Router to return a Promise from it's `getHandler` method. This
+ * is used to simulate what happens when loading a lazy Engine.
+ */
+export default function setupRouterForEngine(hooks) {
+  let getRoute;
+  hooks.beforeEach(function() {
+    let router = this.owner.lookup('router:main');
+    router.reopen({
+      setupRouter() {
+        this._super(...arguments);
+
+        getRoute = this._routerMicrolib.getRoute;
+        this._enginePromises = Object.create(null);
+        this._resolvedEngines = Object.create(null);
+
+        this._routerMicrolib.getRoute = name => {
+          let engineInfo = this._engineInfoByRoute[name];
+          if (!engineInfo) {
+            return getRoute(name);
+          }
+
+          let engineName = engineInfo.name;
+          if (this._resolvedEngines[engineName]) {
+            return getRoute(name);
+          }
+
+          let enginePromise = this._enginePromises[engineName];
+
+          if (!enginePromise) {
+            enginePromise = new RSVP.Promise(resolve => {
+              setTimeout(() => {
+                this._resolvedEngines[engineName] = true;
+
+                resolve();
+              }, 1);
+            });
+            this._enginePromises[engineName] = enginePromise;
+          }
+
+          return enginePromise.then(() => getRoute(name));
+        };
+      }
+    });
+
+    /**
+     * This override is copied from what ember-engines does. It allows handlers to
+     * be loaded asynchronously by not checking the handler directly for meta info
+     */
+    router._getQPMeta = function _newGetQPMeta(handlerInfo) {
+      return this._bucketCache.lookup('route-meta', handlerInfo.name);
+    };
+  });
+
+  hooks.afterEach(function() {
+    this.owner.lookup('router:main')._routerMicrolib.getRoute = getRoute;
+  });
+}
+

--- a/tests/helpers/setup-router-for-engine.js
+++ b/tests/helpers/setup-router-for-engine.js
@@ -42,7 +42,7 @@ export default function setupRouterForEngine(hooks) {
 
           return enginePromise.then(() => getRoute(name));
         };
-      }
+      },
     });
 
     /**
@@ -58,4 +58,3 @@ export default function setupRouterForEngine(hooks) {
     this.owner.lookup('router:main')._routerMicrolib.getRoute = getRoute;
   });
 }
-


### PR DESCRIPTION
When loading a lazy engine ember-prefetch needs to wait engine routes instantiation. This PR takes a different approach than #150 by waiting any route first.
The lazy engine emulation is taken from https://github.com/emberjs/ember.js/blob/fb91c8a96f5f0f496eeadb167dc4676fe49dcf8c/packages/%40ember/-internals/glimmer/tests/integration/application/engine-test.js