### PR TITLE
Ensure both params and path are checked when determining the pivot point

### DIFF
--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -52,12 +52,22 @@ if (gte('3.6.0')) {
     });
   }
 
+  /**
+   * This method checks if from and to routes are navigating away from current route.
+   * For e.g. one navigating from `profile.view` to `profile.details`
+   *
+   * @method pathsDiffer
+   * @param {Object} from - from route list
+   * @param {Object} to - to route list
+   * @return {Array} An array containing mismatch and pivotIndex.
+   * @public
+   */
   pathsDiffer = function(from, to) {
     let pivotIndex = -1;
     let mismatch = false;
     for (let i = 0; i < to.length; i++) {
       let info = to[i];
-      if (info.name !== from[i].name) {
+      if (info.name !== from[i].name || !paramsMatch(info, from[i])) {
         pivotIndex = i;
         mismatch = true;
         break;
@@ -67,6 +77,16 @@ if (gte('3.6.0')) {
     return [mismatch, pivotIndex];
   };
 
+  /**
+   * This check only validate if from and to routes are identical but contains different
+   * parameters.
+   *
+   * @method paramsDiffer
+   * @param {Object} from - from route list
+   * @param {Object} to - to route list
+   * @return {Array} An array containing mismatch and pivotIndex.
+   * @public
+   */
   paramsDiffer = function(from, to) {
     let pivotIndex = -1;
     let mismatch = false;
@@ -154,13 +174,13 @@ if (gte('3.6.0')) {
   };
 
   /**
-    This function checks transition in sequence 
+    This function checks transition in sequence
     1. param has changed
     2. route has changed
     3. query param has changed
     4. refresh has invoked from route
-    
-    This checking sequence is important, changing sequence could impact in weird ways. 
+
+    This checking sequence is important, changing sequence could impact in weird ways.
     For examample, query param invokes route.refresh() if refreshModel is set true on route level.
     If #4 has invoked prior to #3, it will visit index route of refreshModel hence involves in additional API invocation
 

--- a/tests/unit/util/diff-route-infos-test.js
+++ b/tests/unit/util/diff-route-infos-test.js
@@ -101,6 +101,7 @@ if (gte('3.6.0')) {
     test('returns false if the paths are the same', assert => {
       let info = {
         name: 'foo.bar',
+        paramNames: [],
       };
       let [match] = pathsDiffer([info], [info]);
       assert.notOk(match);
@@ -122,6 +123,32 @@ if (gte('3.6.0')) {
       let info2 = assign({}, info, { name: 'baz.bar' });
       let [match] = pathsDiffer([info], [info2]);
       assert.ok(match);
+    });
+
+    test('returns true if the paths and params have changed', assert => {
+      let root = {
+        name: 'root',
+        paramNames: [],
+      };
+      let foo = {
+        name: 'root.foo',
+        paramNames: ['foo_id'],
+      };
+
+      let from = [
+        root,
+        assign({}, foo, { params: { foo_id: 1 } }),
+        { name: 'root.foo.bar', paramNames: [] },
+      ];
+      let to = [
+        root,
+        assign({}, foo, { params: { foo_id: 2 } }),
+        { name: 'root.foo.baz', paramNames: [] },
+      ];
+
+      let [match, pivotIndex] = pathsDiffer(from, to);
+      assert.ok(match);
+      assert.equal(pivotIndex, 1, 'pivot should start from where param has modified');
     });
 
     test('returns true if the paths mismatch', assert => {


### PR DESCRIPTION
If path has different params value then pathDiffer should return correct pivot Index.
Previously, there was no check for params within pathDiffer so route was refreshing from wrong place