### PR TITLE
Make param and path change have equal priority

### DIFF
--- a/addon/-private/diff-route-info.js
+++ b/addon/-private/diff-route-info.js
@@ -175,14 +175,13 @@ if (gte('3.6.0')) {
 
   /**
     This function checks transition in sequence
-    1. param has changed
-    2. route has changed
-    3. query param has changed
-    4. refresh has invoked from route
+    1. param or route has changed
+    2. query param has changed
+    3. refresh has invoked from route
 
     This checking sequence is important, changing sequence could impact in weird ways.
     For examample, query param invokes route.refresh() if refreshModel is set true on route level.
-    If #4 has invoked prior to #3, it will visit index route of refreshModel hence involves in additional API invocation
+    If #3 has invoked prior to #2, it will visit index route of refreshModel hence involves in additional API invocation
 
     @method createPrefetchChangeSet
     @param {Object} privateRouter - router
@@ -199,22 +198,18 @@ if (gte('3.6.0')) {
     }
 
     let paramsResult = paramsDiffer(fromList, toList);
-    let [_paramsDiffer] = paramsResult;
-
-    // Params Changed
-    if (_paramsDiffer) {
-      let [, pivot] = paramsResult;
-      let pivotHandlers = toList.splice(pivot, toList.length);
-      return { shouldCall: true, for: getPrefetched(privateRouter, pivotHandlers) };
-    }
-
-    // Path has changed
+    let [_paramsDiffer, _paramsPivot] = paramsResult;
     let pathResult = pathsDiffer(fromList, toList);
+    let [_pathsDiffer, _pathsPivot] = pathResult;
 
-    let [_pathsDiffer] = pathResult;
-
-    if (_pathsDiffer) {
-      let [, pivot] = pathResult;
+    // Params or Path changed
+    if (_paramsDiffer || _pathsDiffer) {
+      let pivot;
+      if (_paramsDiffer && _pathsDiffer) {
+        pivot = Math.min(_paramsPivot, _pathsPivot);
+      } else {
+        pivot = _paramsDiffer ? _paramsPivot : _pathsPivot;
+      }
       let pivotHandlers = toList.splice(pivot, toList.length);
       return { shouldCall: true, for: getPrefetched(privateRouter, pivotHandlers) };
     }

--- a/tests/acceptance/hook-calls-test.js
+++ b/tests/acceptance/hook-calls-test.js
@@ -178,4 +178,31 @@ module('Route hooks', function(hooks) {
       'feed-1',
     ]);
   });
+
+  test('hook counts for same depth routes', async function(assert) {
+    this.owner.register(
+      'route:step-parent',
+      Route.extend({
+        prefetch() {
+          assert.step('step-parent');
+        },
+      })
+    );
+
+    this.owner.register(
+      'route:step-parent.step-child',
+      Route.extend({
+        prefetch({ id }) {
+          assert.step(`step-child-${id}`);
+          return id;
+        },
+      })
+    );
+
+    await visit('/step-parent/step-child/1');
+
+    await this.owner.lookup('service:router').transitionTo('/parent/sibling');
+
+    assert.verifySteps(['application', 'step-parent', 'step-child-1', 'parent', 'sibling']);
+  });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -28,6 +28,10 @@ Router.map(function() {
     this.route('sibling');
   });
 
+  this.route('step-parent', function() {
+    this.route('step-child', { path: '/step-child/:id' });
+  });
+
   this.route('refresh-parent', function() {
     this.route('refresh-child');
   });

--- a/tests/dummy/app/templates/step-parent.hbs
+++ b/tests/dummy/app/templates/step-parent.hbs
@@ -1,0 +1,2 @@
+STEP PARENT
+{{outlet}}

--- a/tests/dummy/app/templates/step-parent/step-child.hbs
+++ b/tests/dummy/app/templates/step-parent/step-child.hbs
@@ -1,0 +1,1 @@
+STEP CHILD


### PR DESCRIPTION
**Issue**: When transitioning between 2 paths which have both a param difference and path difference, then it is always the depth of the param difference that is considered for the prefetch change set, even if the paths diverge earlier.

**Example**: When navigating from the route `step-parent.step-child` with an `:id` param, to `parent.child` without a param, then the param change is on the child level, while the path change is on the parent level. With param change being considered prior to path change, this leads to only triggering the `prefetch` hook on the child, but not on the parent.

**Solution**: Consider both param and path change in the same step, and if they both change, use the one that changed earlier (if only one of them changed, then keep using that one).